### PR TITLE
NAPSSPO389 - Maven Package (mvn clean install) step_implementer

### DIFF
--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -104,7 +104,7 @@ def test_pom_file_valid_with_namespace_empty_jar ():
             'tssc-results': {
                 'package': {
                     'artifacts': {
-                        'my-app-42.1.jar': os.path.join(temp_dir.path, "target", 'my-app-42.1.jar')
+                        'my-app-42.1.jar': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
                     }
                 }
             }

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -40,7 +40,7 @@ public class App {
             'tssc-results': {
                 'package': {
                     'artifacts': {
-                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, 'my-app-1.0-SNAPSHOT.jar')
+                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, "target", 'my-app-1.0-SNAPSHOT.jar')
                     }
                 }
             }

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -9,7 +9,7 @@ from tssc.step_implementers.package import Maven
 
 from test_utils import *
 
-def test_package_java_mvn_quickstart_single_jar():
+def test_mvn_quickstart_single_jar():
     with TempDirectory() as temp_dir:
         #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")
         #os.makedirs(java_app_class_file)
@@ -45,5 +45,178 @@ public class App {
                 }
             }
         }
+        run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+
+def test_pom_file_valid_old_empty_jar ():
+    with TempDirectory() as temp_dir:
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>42.1</version>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven',
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
+                }
+            }
+        }
+        expected_step_results = {
+            'tssc-results': {
+                'package': {
+                    'artifacts': {
+                        'my-app-42.1.jar': os.path.join(temp_dir.path, "target", 'my-app-42.1.jar')
+                    }
+                }
+            }
+        }
 
         run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+
+def test_pom_file_valid_with_namespace_empty_jar ():
+    with TempDirectory() as temp_dir:
+        temp_dir.write('pom.xml',b'''<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>42.1</version>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+        results_dir_path = os.path.join(temp_dir.path, 'tssc-resutls')
+
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven',
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
+                }
+            }
+        }
+        expected_step_results = {
+            'tssc-results': {
+                'package': {
+                    'artifacts': {
+                        'my-app-42.1.jar': os.path.join(temp_dir.path, "target", 'my-app-42.1.jar')
+                    }
+                }
+            }
+        }
+        run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+
+def test_mvn_quickstart_single_jar_java_error():
+    with TempDirectory() as temp_dir:
+        #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")
+        #os.makedirs(java_app_class_file)
+        temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+public class Fail {
+    public static void main( String[] args ) {
+        System.out.println( "Hello World!" );
+    }
+}''')
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven',
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
+                }
+            }
+        }
+        factory = TSSCFactory(config)
+        with pytest.raises(ValueError):
+            factory.run_step('package')
+
+def test_pom_file_missing_version ():
+    with TempDirectory() as temp_dir:
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven',
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
+                }
+            }
+        }
+        factory = TSSCFactory(config)
+        with pytest.raises(ValueError):
+            factory.run_step('package')
+
+def test_default_pom_file_missing ():
+    config = {
+        'tssc-config': {
+            'package': {
+                'implementer': 'Maven'
+            }
+        }
+    }
+    factory = TSSCFactory(config)
+    with pytest.raises(ValueError):
+        factory.run_step('package', {'pom-file': 'does-not-exist-pom.xml'})
+
+def test_runtime_pom_file_missing ():
+    config = {
+        'tssc-config': {
+            'package': {
+                'implementer': 'Maven'
+            }
+        }
+    }
+    factory = TSSCFactory(config)
+    with pytest.raises(ValueError):
+        factory.run_step('package', {'pom-file': 'does-not-exist-pom.xml'})
+
+def test_config_file_pom_file_missing ():
+    config = {
+        'tssc-config': {
+            'package': {
+                'implementer': 'Maven',
+                'config': {
+                    'pom-file': 'does-not-exist.pom'
+                }
+            }
+        }
+    }
+    factory = TSSCFactory(config)
+    with pytest.raises(ValueError):
+        factory.run_step('package')
+
+def test_config_file_pom_file_none_value ():
+    config = {
+        'tssc-config': {
+            'package': {
+                'implementer': 'Maven',
+                'config': {
+                    'pom-file': None
+                }
+            }
+        }
+    }
+    factory = TSSCFactory(config)
+    with pytest.raises(ValueError):
+        factory.run_step('package')

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -38,7 +38,7 @@ public class App {
             'tssc-results': {
                 'package': {
                     'artifacts': {
-                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, "target", 'my-app-1.0-SNAPSHOT.jar')
+                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
                     }
                 }
             }
@@ -68,7 +68,7 @@ def test_pom_file_valid_old_empty_jar ():
             'tssc-results': {
                 'package': {
                     'artifacts': {
-                        'my-app-42.1.jar': os.path.join(temp_dir.path, "target", 'my-app-42.1.jar')
+                        'my-app-42.1.jar': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
                     }
                 }
             }

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -9,13 +9,22 @@ from tssc.step_implementers.package import Maven
 
 from test_utils import *
 
-def test_tag_source_specify_git_implementer():
+
+def test_package_java_mvn_quickstart_single_jar():
     with TempDirectory() as temp_dir:
+        #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")
+        #os.makedirs(java_app_class_file)
+        temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+public class App {
+    public static void main( String[] args ) {
+        System.out.println( "Hello World!" );
+    }
+}''')
         temp_dir.write('pom.xml',b'''<project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mycompany.app</groupId>
     <artifactId>my-app</artifactId>
-    <version>42.1</version>
+    <version>1.0-SNAPSHOT</version>
 </project>''')
         pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
         config = {
@@ -28,6 +37,14 @@ def test_tag_source_specify_git_implementer():
                 }
             }
         }
-        expected_step_results = {'tssc-results': {'package': {}}}
+        expected_step_results = {
+            'tssc-results': {
+                'package': {
+                    'artifacts': {
+                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, 'my-app-1.0-SNAPSHOT.jar')
+                    }
+                }
+            }
+        }
 
         run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -9,7 +9,6 @@ from tssc.step_implementers.package import Maven
 
 from test_utils import *
 
-
 def test_package_java_mvn_quickstart_single_jar():
     with TempDirectory() as temp_dir:
         #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -113,8 +113,6 @@ def test_pom_file_valid_with_namespace_empty_jar ():
 
 def test_mvn_quickstart_single_jar_java_error():
     with TempDirectory() as temp_dir:
-        #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")
-        #os.makedirs(java_app_class_file)
         temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
 public class Fail {
     public static void main( String[] args ) {

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -11,11 +11,20 @@ from test_utils import *
 
 def test_tag_source_specify_git_implementer():
     with TempDirectory() as temp_dir:
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>42.1</version>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
         config = {
-            'tssc-config': {    
+            'tssc-config': {
                 'package': {
                     'implementer': 'Maven',
-                    'config': {}
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
                 }
             }
         }

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -11,8 +11,6 @@ from test_utils import *
 
 def test_mvn_quickstart_single_jar():
     with TempDirectory() as temp_dir:
-        #java_app_class_file = os.path.join(temp_dir.path,"src/main/java/com/mycompany/app/app.java")
-        #os.makedirs(java_app_class_file)
         temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
 public class App {
     public static void main( String[] args ) {

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -87,6 +87,7 @@ class Maven(StepImplementer):
         }
         for artifact in java_packaged_artifacts:
             results['artifacts'][artifact] = os.path.join(os.path.dirname(pom_file),artifact)
+
         return results
 
 # register step implementer

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -67,14 +67,26 @@ class Maven(StepImplementer):
         pom_file = runtime_step_config['pom-file']
 
         process_args = ["mvn", "clean", "install"]
+        java_artifact_extenstions = ["jar", "war", "ear"]
+        return_code = 1
 
         with ChangeDir(os.path.dirname(pom_file)):
             return_code = subprocess.call(process_args)
         if return_code:
             raise ValueError('Issue invoking ' + str(process_args) + \
               ' with given pom file (' + pom_file + ')')
+
+        included_extensions = ['jpg','jpeg', 'bmp', 'png', 'gif']
+        java_packaged_artifacts = [filename for filename in \
+          os.listdir(os.path.join(os.path.dirname(pom_file), "target"))
+            if any(filename.endswith(ext) for ext in java_artifact_extenstions)]
+
         results = {
+            'artifacts' : {
+            }
         }
+        for artifact in java_packaged_artifacts:
+            results['artifacts'][artifact] = os.path.join(os.path.dirname(pom_file),artifact)
         return results
 
 # register step implementer

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -66,6 +66,9 @@ class Maven(StepImplementer):
     def _run_step(self, runtime_step_config):
         pom_file = runtime_step_config['pom-file']
 
+        if not os.path.exists(pom_file):
+            raise ValueError('Given pom file does not exist: ' + pom_file)
+
         process_args = ["mvn", "clean", "install"]
         java_artifact_extenstions = ["jar", "war", "ear"]
         return_code = 1

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -76,17 +76,18 @@ class Maven(StepImplementer):
             raise ValueError('Issue invoking ' + str(process_args) + \
               ' with given pom file (' + pom_file + ')')
 
-        included_extensions = ['jpg','jpeg', 'bmp', 'png', 'gif']
-        java_packaged_artifacts = [filename for filename in \
-          os.listdir(os.path.join(os.path.dirname(pom_file), "target"))
-            if any(filename.endswith(ext) for ext in java_artifact_extenstions)]
+        java_packaged_artifacts = []
+        for filename in os.listdir(os.path.join(os.path.dirname(pom_file), "target")):
+            if any(filename.endswith(ext) for ext in java_artifact_extenstions):
+                java_packaged_artifacts.append(filename)
 
         results = {
             'artifacts' : {
             }
         }
         for artifact in java_packaged_artifacts:
-            results['artifacts'][artifact] = os.path.join(os.path.dirname(pom_file),artifact)
+            results['artifacts'][artifact] = \
+              os.path.join(os.path.dirname(pom_file), "target", artifact)
 
         return results
 

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -1,16 +1,45 @@
 """
 Step Implementer for the package step for Maven.
 """
+import os
+import subprocess
 
 from tssc import TSSCFactory
 from tssc import StepImplementer
 from tssc import DefaultSteps
 
-DEFAULT_ARGS = {}
+DEFAULT_ARGS = {
+    'pom-file': 'pom.xml'
+}
+
+# https://stackoverflow.com/questions/21377520/do-a-maven-build-in-a-python-script
+class ChangeDir:
+    """
+    Internal helper class to manage changing directories, and returning to the
+    starting working directory.
+    """
+    def __init__(self, new_path):
+        self.saved_path = None
+        self.new_path = os.path.expanduser(new_path)
+
+    # Change directory with the new path
+    def __enter__(self):
+        self.saved_path = os.getcwd()
+        os.chdir(self.new_path)
+
+    # Return back to previous directory
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.saved_path)
 
 class Maven(StepImplementer):
     """
     StepImplementer for the package step for Maven.
+
+    Raises
+    ------
+    ValueError
+        If given pom file does not exist
+        If given pom file does not contain required elements
     """
 
     def __init__(self, config, results_file):
@@ -29,11 +58,23 @@ class Maven(StepImplementer):
         step_config : dict
             Step configuration to validate.
         """
+        print(step_config)
+
+        if 'pom-file' not in step_config or not step_config['pom-file']:
+            raise ValueError('Key (pom-file) must have none empty value in the step configuration')
 
     def _run_step(self, runtime_step_config):
+        pom_file = runtime_step_config['pom-file']
+
+        process_args = ["mvn", "clean", "install"]
+
+        with ChangeDir(os.path.dirname(pom_file)):
+            return_code = subprocess.call(process_args)
+        if return_code:
+            raise ValueError('Issue invoking ' + str(process_args) + \
+              ' with given pom file (' + pom_file + ')')
         results = {
         }
-
         return results
 
 # register step implementer


### PR DESCRIPTION
This is a pull request for https://projects.engineering.redhat.com/browse/NAPSSPO-390

This covers the MVP for maven for the package (build) step_implementer. The test cases cover success as well as malformed poms, missing poms, and failed java compilation. It should work with POMs that have multiple output artifacts, but I didn't write test cases for that, as it is a anti-pattern IMHO.

It spits out the results in the following format:

'tssc-results': {
    'package': {
        'artifacts': {
            'my-app-42.1.jar': '/some/path/my-app-42.1.jar')
         }
     }
}