### PR TITLE
NAPSSPO-392

### DIFF
--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -3,11 +3,14 @@ import yaml
 from tssc import TSSCFactory
 
 
-def run_step_test_with_result_validation(temp_dir, step_name, config, expected_step_results):
+def run_step_test_with_result_validation(temp_dir, step_name, config, expected_step_results, runtime_args=None):
     results_dir_path = os.path.join(temp_dir.path, 'tssc-results')
 
     factory = TSSCFactory(config, results_dir_path)
-    factory.run_step(step_name)
+    if runtime_args:
+        factory.run_step(step_name, runtime_args)
+    else:
+        factory.run_step(step_name)
 
     results_file_name = "%s.yml" % step_name
     with open(os.path.join(results_dir_path, results_file_name), 'r') as step_results_file:

--- a/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
@@ -10,6 +10,26 @@ from tssc.step_implementers.generate_metadata import Maven
 
 from test_utils import *
 
+
+def test_pom_file_valid_runtime_config_pom_file():
+    with TempDirectory() as temp_dir:
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>42.1</version>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+        config = {
+            'tssc-config': {
+                'generate-metadata': {
+                    'implementer': 'Maven'
+                }
+            }
+        }
+        expected_step_results = {'tssc-results': {'generate-metadata': {'version': '42.1'}}}
+        run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'pom-file': str(pom_file_path)})
+
 def test_pom_file_valid_old ():
     with TempDirectory() as temp_dir:
         temp_dir.write('pom.xml',b'''<project>
@@ -60,26 +80,6 @@ def test_pom_file_valid_with_namespace():
         expected_step_results = {'tssc-results': {'generate-metadata': {'version': '42.1'}}}
 
         run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results)
-            
-def test_pom_file_valid_runtime_config_pom_file():
-    config = {
-        'tssc-config': {
-            'generate-metadata': {
-                'implementer': 'Maven'
-            }
-        }
-    }
-    factory = TSSCFactory(config)
-
-    with TempDirectory() as temp_dir:
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>42.1</version>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
-        factory.run_step('generate-metadata', {'pom-file': str(pom_file_path)})
 
 def test_pom_file_missing_version():
     with TempDirectory() as temp_dir:


### PR DESCRIPTION
Updated the test_utils.py to allow optional runtime args to be passed in, defaults to None. Then modified test_maven_generate_metadata.py to take advantage of that for testing