### PR TITLE
NAPSSPO-389 Added shell=true to subprocess for mvn package

### DIFF
--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -74,7 +74,7 @@ class Maven(StepImplementer):
         return_code = 1
 
         with ChangeDir(os.path.dirname(os.path.abspath(pom_file))):
-            return_code = subprocess.call(process_args)
+            return_code = subprocess.call(process_args, shell=True)
         if return_code:
             raise ValueError('Issue invoking ' + str(process_args) + \
               ' with given pom file (' + pom_file + ')')

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -69,7 +69,7 @@ class Maven(StepImplementer):
         if not os.path.exists(pom_file):
             raise ValueError('Given pom file does not exist: ' + pom_file)
 
-        process_args = ["mvn", "clean", "install"]
+        process_args = 'mvn clean install'
         java_artifact_extenstions = ["jar", "war", "ear"]
         return_code = 1
 


### PR DESCRIPTION
so using shell=True is a significant security risk in a python subprocess command, but I believe the risk of rogue command injection is directly mitigated by the fact that the command is hard coded as a variable, and is therefore unreachable by user input. 