### PR TITLE
WIP Napsspo 526

### DIFF
--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -15,7 +15,7 @@ class dummy_context_mgr():
 class WriteConfigAsResultsStepImplementer(StepImplementer):
     def __init__(self, config, results_file):
         super().__init__(config, results_file, {})
-    
+
     @classmethod
     def step_name(cls):
         return 'write-config-as-results'
@@ -27,11 +27,11 @@ def _run_step_implementer_test(config, step, expected_step_results, test_dir):
     results_dir_path = os.path.join(test_dir.path, 'tssc-results')
     factory = TSSCFactory(config, results_dir_path)
     factory.run_step(step)
-    
+
     with open(os.path.join(results_dir_path, "%s.yml" % step), 'r') as step_results_file:
         step_results = yaml.safe_load(step_results_file.read())
         assert step_results == expected_step_results
-        
+
 def test_one_step_writes_to_empty_results_file():
     config1 = {
         'tssc-config': {
@@ -52,9 +52,9 @@ def test_one_step_writes_to_empty_results_file():
             }
         }
     }
-    
+
     TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
-    with TempDirectory() as test_dir: 
+    with TempDirectory() as test_dir:
         _run_step_implementer_test(
             config1,
             'write-config-as-results',
@@ -102,9 +102,9 @@ def test_merge_results_from_running_same_step_twice_with_different_config():
             }
         }
     }
-    
+
     TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
-    
+
     with TempDirectory() as test_dir:
         _run_step_implementer_test(
             config1,
@@ -149,9 +149,9 @@ def test_merge_results_from_two_sub_steps():
             }
         }
     }
-    
+
     TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
-    
+
     with TempDirectory() as test_dir:
         _run_step_implementer_test(
             config,
@@ -172,13 +172,13 @@ def test_one_step_existing_results_file_bad_yaml():
             }
         }
     }
-    
+
     TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
     with TempDirectory() as test_dir:
         results_dir_path = os.path.join(test_dir.path, 'tssc-results')
         results_file_path = os.path.join(results_dir_path, 'write-config-as-results.yml')
         test_dir.write(results_file_path,b'''{}bad[yaml}''')
-        
+
         with pytest.raises(TSSCException):
             _run_step_implementer_test(
                 config,
@@ -186,6 +186,41 @@ def test_one_step_existing_results_file_bad_yaml():
                 None,
                 test_dir
             )
+
+def test_one_step_existing_results_file():
+    config = {
+        'tssc-config': {
+            'write-config-as-results': {
+                'implementer': 'WriteConfigAsResultsStepImplementer',
+                'config': {
+                    'config-1': "config-1",
+                    'config-overwrite-me': 'config-1'
+                }
+            }
+        }
+    }
+
+    config_expected_step_results = {
+        'tssc-results': {
+            'write-config-as-results': {
+                'config-1': "config-1",
+                'config-overwrite-me': 'config-1'
+            },
+        }
+    }
+
+    TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
+    with TempDirectory() as test_dir:
+        results_dir_path = os.path.join(test_dir.path, 'tssc-results')
+        results_file_path = os.path.join(results_dir_path, 'test-step.yml')
+        test_dir.write(results_file_path,b'''tssc-results: {'test-step': {}}''')
+        print(b'''tssc-results: {'test-step': {}}''')
+        _run_step_implementer_test(
+            config,
+            'write-config-as-results',
+            config_expected_step_results,
+            test_dir
+        )
 
 def test_one_step_existing_results_file_missing_key():
     config = {
@@ -199,13 +234,13 @@ def test_one_step_existing_results_file_missing_key():
             }
         }
     }
-    
+
     TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
     with TempDirectory() as test_dir:
         results_dir_path = os.path.join(test_dir.path, 'tssc-results')
         results_file_path = os.path.join(results_dir_path, 'write-config-as-results.yml')
         test_dir.write(results_file_path,b'''not-expected-root-key-for-results: {}''')
-        
+
         with pytest.raises(TSSCException):
             _run_step_implementer_test(
                 config,

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -248,3 +248,36 @@ def test_one_step_existing_results_file_missing_key():
                 None,
                 test_dir
             )
+def test_one_step_existing_file_in_results_dir_not_yml():
+    config = {
+        'tssc-config': {
+            'write-config-as-results': {
+                'implementer': 'WriteConfigAsResultsStepImplementer',
+                'config': {
+                    'config-1': "config-1",
+                    'config-overwrite-me': 'config-1'
+                }
+            }
+        }
+    }
+
+    config_expected_step_results = {
+        'tssc-results': {
+            'write-config-as-results': {
+                'config-1': "config-1",
+                'config-overwrite-me': 'config-1'
+            },
+        }
+    }
+
+    TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
+    with TempDirectory() as test_dir:
+        results_dir_path = os.path.join(test_dir.path, 'tssc-results')
+        results_file_path = os.path.join(results_dir_path, 'write-config-as-results.test')
+        test_dir.write(results_file_path,b'''test: {}''')
+        _run_step_implementer_test(
+            config,
+            'write-config-as-results',
+            config_expected_step_results,
+            test_dir
+        )

--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -256,7 +256,7 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
                             if StepImplementer.__TSSC_RESULTS_KEY not in tmp_results:
                                 raise TSSCException(
                                     'Existing results file'
-                                    +' (' + step_results_file + ')'
+                                    +' (' + step_results_file_name + ')'
                                     +' does not have expected top level element'
                                     +' (' + StepImplementer.__TSSC_RESULTS_KEY + '): '
                                     + str(tmp_results)
@@ -270,7 +270,7 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
                           as err:
                             raise TSSCException(
                                 'Existing results file'
-                                +' (' + step_results_file + ')'
+                                +' (' + step_results_file_name + ')'
                                 +' for step (' + self.step_name() + ')'
                                 +' has invalid yaml: ' + str(err)
                             )

--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -249,7 +249,8 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
             for step_results_file_name in os.listdir(self.results_dir_path):
                 if step_results_file_name.endswith(".yml"):
                     step_results_files_found += 1
-                    with open(os.path.join(self.results_dir_path, step_results_file_name), 'r') as step_results_file:
+                    with open(os.path.join(self.results_dir_path, step_results_file_name), 'r') \
+                      as step_results_file:
                         try:
                             tmp_results = yaml.safe_load(step_results_file.read())
                             if StepImplementer.__TSSC_RESULTS_KEY not in tmp_results:
@@ -261,10 +262,12 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
                                     + str(tmp_results)
                                 )
                             if current_results:
-                                current_results[StepImplementer.__TSSC_RESULTS_KEY].update(tmp_results[StepImplementer.__TSSC_RESULTS_KEY])
+                                current_results[StepImplementer.__TSSC_RESULTS_KEY].update( \
+                                  tmp_results[StepImplementer.__TSSC_RESULTS_KEY])
                             else:
                                 current_results = tmp_results
-                        except (yaml.scanner.ScannerError, yaml.parser.ParserError, ValueError) as err:
+                        except (yaml.scanner.ScannerError, yaml.parser.ParserError, ValueError) \
+                          as err:
                             raise TSSCException(
                                 'Existing results file'
                                 +' (' + step_results_file + ')'
@@ -274,7 +277,8 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
             if step_results_files_found == 0:
                 current_results = init_result
         if self.step_name() not in current_results[StepImplementer.__TSSC_RESULTS_KEY]:
-            current_results[StepImplementer.__TSSC_RESULTS_KEY].update(init_result[StepImplementer.__TSSC_RESULTS_KEY])
+            current_results[StepImplementer.__TSSC_RESULTS_KEY].update( \
+              init_result[StepImplementer.__TSSC_RESULTS_KEY])
         return current_results
 
     def get_step_results(self, step_name):

--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -267,7 +267,7 @@ class StepImplementer(ABC):  # pylint: disable=too-few-public-methods
                         except (yaml.scanner.ScannerError, yaml.parser.ParserError, ValueError) as err:
                             raise TSSCException(
                                 'Existing results file'
-                                +' (' + step_results_file_path + ')'
+                                +' (' + step_results_file + ')'
                                 +' for step (' + self.step_name() + ')'
                                 +' has invalid yaml: ' + str(err)
                             )


### PR DESCRIPTION
NAPSSPO-526 significantly modified the logic of current_results, so that it will look through the tssc results dir and return all the results. The behavior was what was planned for, but it was in fact only returning the logic for the current step