### PR TITLE
NAPSSPO-538 drop support for multiple artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ python -m pip install -e '.[tests]'
 python -m pytest --cov=tssc tests/
 ```
 
+Or to run for just a particular implementer, and include the sections of code that you didn't cover
+
+```bash
+python3 -m pytest --cov=tssc tests/step_implementers/package/test_maven_package.py --cov-report term-missing
+```
+
 ### Run linter
 ```bash
 python -m pylint --rcfile=setup.cfg tssc

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -74,6 +74,90 @@ public class App {
         }
         run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
 
+def test_mvn_multiple_jars():
+    with TempDirectory() as temp_dir:
+        temp_dir.write('src/main/java/com/mycompanya/app/App.java',b'''package com.mycompanya.app;
+public class App {
+    public static void main( String[] args ) {
+        System.out.println( "Hello World!" );
+    }
+}''')
+        temp_dir.write('src/main/java/com/mycompanyb/app/App.java',b'''package com.mycompanyb.app;
+public class App {
+    public static void main( String[] args ) {
+        System.out.println( "Hello World!" );
+    }
+}''')
+        temp_dir.write('pom.xml',b'''<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jar1</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.mycompanya.app.App</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <finalName>companya</finalName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jar2</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.mycompanyb.app.App</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <finalName>companyb</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>''')
+        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven',
+                    'config': {
+                        'pom-file': str(pom_file_path)
+                    }
+                }
+            }
+        }
+        factory = TSSCFactory(config)
+        with pytest.raises(ValueError):
+            factory.run_step('package')
+
 def test_pom_file_valid_old_empty_jar ():
     with TempDirectory() as temp_dir:
         temp_dir.write('pom.xml',b'''<project>

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -28,9 +28,7 @@ public class App {
         expected_step_results = {
             'tssc-results': {
                 'package': {
-                    'artifacts': {
-                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
-                    }
+                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
                 }
             }
         }
@@ -70,9 +68,7 @@ public class App {
         expected_step_results = {
             'tssc-results': {
                 'package': {
-                    'artifacts': {
-                        'my-app-1.0-SNAPSHOT.jar': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
-                    }
+                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
                 }
             }
         }
@@ -100,9 +96,7 @@ def test_pom_file_valid_old_empty_jar ():
         expected_step_results = {
             'tssc-results': {
                 'package': {
-                    'artifacts': {
-                        'my-app-42.1.jar': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
-                    }
+                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
                 }
             }
         }
@@ -136,9 +130,7 @@ def test_pom_file_valid_with_namespace_empty_jar ():
         expected_step_results = {
             'tssc-results': {
                 'package': {
-                    'artifacts': {
-                        'my-app-42.1.jar': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
-                    }
+                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
                 }
             }
         }

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -9,7 +9,7 @@ from tssc import StepImplementer
 from tssc import DefaultSteps
 
 DEFAULT_ARGS = {
-    'pom-file': 'pom.xml'
+    'pom-file': 'pom.xml',
     'artifact-extensions': ["jar", "war", "ear"]
 }
 

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -84,7 +84,7 @@ class Maven(StepImplementer):
           'target')):
             if any(filename.endswith(ext) for ext in java_artifact_extenstions):
                 java_packaged_artifacts.append(filename)
-        if len(java_packaged_artifacts) > 1:
+        if len(java_packaged_artifacts) > 1: # pragma: no cover
             raise ValueError('pom resulted in multiple artifacts, this is unsupported')
         results = {
             'artifact' : os.path.join(os.path.dirname(os.path.abspath(pom_file)), "target", \

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -10,6 +10,7 @@ from tssc import DefaultSteps
 
 DEFAULT_ARGS = {
     'pom-file': 'pom.xml'
+    'artifact-extensions': ["jar", "war", "ear"]
 }
 
 # https://stackoverflow.com/questions/21377520/do-a-maven-build-in-a-python-script
@@ -33,7 +34,9 @@ class ChangeDir:
 
 class Maven(StepImplementer):
     """
-    StepImplementer for the package step for Maven.
+    StepImplementer for the package step for Maven. It is assumed thought that there will
+    only be a single jar, ear, or war output for running mvn clean install against the given
+    pom.xml file.
 
     Raises
     ------
@@ -65,12 +68,12 @@ class Maven(StepImplementer):
 
     def _run_step(self, runtime_step_config):
         pom_file = runtime_step_config['pom-file']
+        artifact_extensions = runtime_step_config['artifact-extensions']
 
         if not os.path.exists(pom_file):
             raise ValueError('Given pom file does not exist: ' + pom_file)
 
         process_args = 'mvn clean install'
-        java_artifact_extenstions = ["jar", "war", "ear"]
         return_code = 1
 
         with ChangeDir(os.path.dirname(os.path.abspath(pom_file))):
@@ -82,7 +85,7 @@ class Maven(StepImplementer):
         java_packaged_artifacts = []
         for filename in os.listdir(os.path.join(os.path.dirname(os.path.abspath(pom_file)), \
           'target')):
-            if any(filename.endswith(ext) for ext in java_artifact_extenstions):
+            if any(filename.endswith(ext) for ext in artifact_extensions):
                 java_packaged_artifacts.append(filename)
         if len(java_packaged_artifacts) > 1:
             raise ValueError('pom resulted in multiple artifacts, this is unsupported')

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -84,7 +84,7 @@ class Maven(StepImplementer):
           'target')):
             if any(filename.endswith(ext) for ext in java_artifact_extenstions):
                 java_packaged_artifacts.append(filename)
-        if len(java_packaged_artifacts) > 1: # pragma: no cover
+        if len(java_packaged_artifacts) > 1:
             raise ValueError('pom resulted in multiple artifacts, this is unsupported')
         results = {
             'artifact' : os.path.join(os.path.dirname(os.path.abspath(pom_file)), "target", \

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -84,15 +84,12 @@ class Maven(StepImplementer):
           'target')):
             if any(filename.endswith(ext) for ext in java_artifact_extenstions):
                 java_packaged_artifacts.append(filename)
-
+        if len(java_packaged_artifacts) > 1:
+            raise ValueError('pom resulted in multiple artifacts, this is unsupported')
         results = {
-            'artifacts' : {
-            }
+            'artifact' : os.path.join(os.path.dirname(os.path.abspath(pom_file)), "target", \
+              java_packaged_artifacts[0])
         }
-        for artifact in java_packaged_artifacts:
-            results['artifacts'][artifact] = \
-              os.path.join(os.path.dirname(os.path.abspath(pom_file)), "target", artifact)
-
         return results
 
 # register step implementer


### PR DESCRIPTION
modified the packaging so that it no longer support several artifacts being created, and will instead throw a value error if you attempt to provide a pom.xml that will result in several

            'tssc-results': {
                'package': {
                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar')
                }
            }