### PR TITLE
tssc/step_implementers/package/maven.py - update to use sh rather then subprocess

### DIFF
--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -1,345 +1,623 @@
 import os
+import sh
+from pathlib import Path
 
-import pytest
+import unittest
+from unittest.mock import patch
 from testfixtures import TempDirectory
-import yaml
 
 from tssc import TSSCFactory
 from tssc.step_implementers.package import Maven
 
 from test_utils import *
 
-def test_mvn_quickstart_single_jar_no_pom():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
-public class App {
-    public static void main( String[] args ) {
-        System.out.println( "Hello World!" );
-    }
-}''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+def create_mvn_side_effect(pom_file, artifact_parent_dir, artifact_names):
+    """simulates what mvn does by touching files.
+    
+    Notes
+    -----
+    
+    Supports
+    
+    - mvn clean
+    - mvn install
+    
+    """
+    target_dir_path = os.path.join(
+        os.path.dirname(os.path.abspath(pom_file)),
+        artifact_parent_dir)
+
+    
+    def mvn_side_effect(*args):
+        if 'clean' in args:
+            if os.path.exists(target_dir_path):
+                os.rmdir(target_dir_path)
+        
+        if 'install' in args:
+            os.mkdir(target_dir_path)
+            
+            for artifact_name in artifact_names:
+                artifact_path = os.path.join(
+                    target_dir_path,
+                    artifact_name
+                )
+                Path(artifact_path).touch()
+    
+    return mvn_side_effect
+        
+
+class TestStepImplementerPackageMaven(unittest.TestCase):
+    @patch('sh.mvn', create=True)
+    def test_mvn_quickstart_single_jar_no_pom(self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                    }
+                }
+            }
+            factory = TSSCFactory(config)
+            with self.assertRaisesRegex(
+                    ValueError, 
+                    'Given pom file does not exist: .*'):
+                factory.run_step('package')
+    
+    @patch('sh.mvn', create=True)
+    def test_mvn_quickstart_single_jar(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '1.0'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+        <properties>
+            <maven.compiler.source>1.8</maven.compiler.source>
+            <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            expected_step_results = {
+                'tssc-results': {
+                    'package': {
+                        'artifacts': [{
+                            'path': os.path.join(
+                                temp_dir.path,
+                                'target',
+                                artfiact_file_name
+                            ),
+                            'artifact-id': artifact_id,
+                            'group-id': 'com.mycompany.app',
+                            'package-type': package,
+                            'pom-path': str(pom_file_path)
+                        }]
+                    }
+                }
+            }
+            
+            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artfiact_file_name])
+            run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            mvn_mock.assert_called_once_with('clean', 'install', '-f', pom_file_path)
+    
+    @patch('sh.mvn', create=True)
+    def test_mvn_quickstart_no_jar(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '1.0'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            expected_step_results = {
+                'tssc-results': {
+                    'package': {
+                        'artifacts': [{
+                            'path': os.path.join(
+                                temp_dir.path,
+                                'target',
+                                artfiact_file_name
+                            ),
+                            'artifact-id': 'my-app',
+                            'group-id': 'com.mycompany.app'
+                        }]
+                    }
+                }
+            }
+            
+            # NOTE:
+            # sort of hacking this test by passing in no artifacts to cause the no artifacts error message
+            # because can't figure out how to create a pom that doesn't generate any artifacts
+            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [])
+            
+            with self.assertRaisesRegex(
+                    ValueError, 
+                    'pom resulted in 0 with expected artifact extensions (.*), this is unsupported'):
+                
+                    run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+    
+    @patch('sh.mvn', create=True)
+    def test_mvn_multiple_jars(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '1.0'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompanya/app/App.java',b'''package com.mycompanya.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write('src/main/java/com/mycompanyb/app/App.java',b'''package com.mycompanyb.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+        <properties>
+            <maven.compiler.source>1.8</maven.compiler.source>
+            <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
+        <build>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>jar1</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                            <configuration>
+                                <archive>
+                                    <manifest>
+                                        <mainClass>com.mycompanya.app.App</mainClass>
+                                    </manifest>
+                                </archive>
+                                <descriptorRefs>
+                                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                                </descriptorRefs>
+                                <finalName>companya</finalName>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>jar2</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                            <configuration>
+                                <archive>
+                                    <manifest>
+                                        <mainClass>com.mycompanyb.app.App</mainClass>
+                                    </manifest>
+                                </archive>
+                                <descriptorRefs>
+                                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                                </descriptorRefs>
+                                <finalName>companyb</finalName>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            factory = TSSCFactory(config)
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            
+            mvn_mock.side_effect = create_mvn_side_effect(
+                pom_file_path,
+                'target',
+                [
+                    'companya-{version}-jar-with-dependencies.jar'.format(version=version),
+                    'companyb-{version}-jar-with-dependencies.jar'.format(version=version),
+                    artfiact_file_name
+                ]
+            )
+            
+            with self.assertRaisesRegex(
+                    ValueError, 
+                    'pom resulted in multiple artifacts with expected artifact extensions (.*), this is unsupported'):
+                factory.run_step('package')
+    
+    @patch('sh.mvn', create=True)
+    def test_pom_file_valid_old_empty_jar(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '42.1'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            expected_step_results = {
+                'tssc-results': {
+                    'package': {
+                        'artifacts': [{
+                            'path': os.path.join(temp_dir.path, 'target', artfiact_file_name),
+                            'artifact-id': artifact_id,
+                            'group-id': 'com.mycompany.app',
+                            'package-type': package,
+                            'pom-path': str(pom_file_path)
+                        }]
+                    }
+                }
+            }
+    
+            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artfiact_file_name])
+            run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            mvn_mock.assert_called_once_with('clean', 'install', '-f', pom_file_path)
+    
+    @patch('sh.mvn', create=True)
+    def test_pom_file_valid_with_namespace_empty_jar(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '42.1'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<?xml version="1.0"?>
+    <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+      xmlns="http://maven.apache.org/POM/4.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+    
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            expected_step_results = {
+                'tssc-results': {
+                    'package': {
+                        'artifacts': [{
+                            'path': os.path.join(temp_dir.path, 'target', artfiact_file_name),
+                            'artifact-id': artifact_id,
+                            'group-id': 'com.mycompany.app',
+                            'package-type': package,
+                            'pom-path': str(pom_file_path)
+                        }]
+                    }
+                }
+            }
+            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artfiact_file_name])
+            run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            mvn_mock.assert_called_once_with('clean', 'install', '-f', pom_file_path)
+    
+    @patch('sh.mvn', create=True, side_effect = sh.ErrorReturnCode('mvn clean install', b'mock out', b'Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project my-app: Compilation failure: Compilation failure'))
+    def test_mvn_quickstart_single_jar_java_error(self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+    public class Fail {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write('pom.xml',b'''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>my-app</artifactId>
+        <version>1.0</version>
+    </project>''')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            factory = TSSCFactory(config)
+            with self.assertRaisesRegex(
+                    RuntimeError, 
+                    'Error invoking mvn:.*'):
+                factory.run_step('package')
+    
+    @patch('sh.mvn', create=True)
+    def test_pom_file_missing_groupId (self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.write('pom.xml',b'''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <artifactId>my-app</artifactId>
+        <version>1.0</version>
+    </project>''')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+    
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            factory = TSSCFactory(config)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Given xml file \(.*\) does not have ./groupId element"):
+                mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [])
+                factory.run_step('package')
+    
+    @patch('sh.mvn', create=True)
+    def test_pom_file_missing_artifactId (self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.write('pom.xml',b'''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <version>1.0</version>
+    </project>''')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+    
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
+                    }
+                }
+            }
+            factory = TSSCFactory(config)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Given xml file \(.*\) does not have ./artifactId element"):
+                mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [])
+                factory.run_step('package')
+    
+    @patch('sh.mvn', create=True)
+    def test_default_pom_file_missing(self, mvn_mock):
         config = {
             'tssc-config': {
                 'package': {
-                    'implementer': 'Maven',
-                }
-            }
-        }
-        expected_step_results = {
-            'tssc-results': {
-                'package': {
-                    'artifact': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar')
+                    'implementer': 'Maven'
                 }
             }
         }
         factory = TSSCFactory(config)
-        with pytest.raises(ValueError):
+        with self.assertRaisesRegex(
+                ValueError, 
+                "Given pom file does not exist: pom.xml"):
             factory.run_step('package')
-
-def test_mvn_quickstart_single_jar():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
-public class App {
-    public static void main( String[] args ) {
-        System.out.println( "Hello World!" );
-    }
-}''')
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+    
+    @patch('sh.mvn', create=True)
+    def test_runtime_pom_file_missing(self, mvn_mock):
+        config = {
+            'tssc-config': {
+                'package': {
+                    'implementer': 'Maven'
+                }
+            }
+        }
+        factory = TSSCFactory(config)
+        with self.assertRaisesRegex(
+                ValueError, 
+                "Given pom file does not exist: does-not-exist-pom.xml"):
+            factory.run_step('package', {'pom-file': 'does-not-exist-pom.xml'})
+    
+    @patch('sh.mvn', create=True)
+    def test_config_file_pom_file_missing(self, mvn_mock):
         config = {
             'tssc-config': {
                 'package': {
                     'implementer': 'Maven',
                     'config': {
-                        'pom-file': str(pom_file_path)
-                    }
-                }
-            }
-        }
-        expected_step_results = {
-            'tssc-results': {
-                'package': {
-                    'artifacts': [{
-                        'path': os.path.join(temp_dir.path, 'target', 'my-app-1.0-SNAPSHOT.jar'),
-                        'artifact-id': 'my-app',
-                        'group-id': 'com.mycompany.app',
-                        'package-type': 'jar',
-                        'pom-path': str(pom_file_path)
-                    }]
-                }
-            }
-        }
-        run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
-
-def test_mvn_multiple_jars():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('src/main/java/com/mycompanya/app/App.java',b'''package com.mycompanya.app;
-public class App {
-    public static void main( String[] args ) {
-        System.out.println( "Hello World!" );
-    }
-}''')
-        temp_dir.write('src/main/java/com/mycompanyb/app/App.java',b'''package com.mycompanyb.app;
-public class App {
-    public static void main( String[] args ) {
-        System.out.println( "Hello World!" );
-    }
-}''')
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jar1</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>com.mycompanya.app.App</mainClass>
-                                </manifest>
-                            </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                            <finalName>companya</finalName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jar2</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>com.mycompanyb.app.App</mainClass>
-                                </manifest>
-                            </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                            <finalName>companyb</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
-        config = {
-            'tssc-config': {
-                'package': {
-                    'implementer': 'Maven',
-                    'config': {
-                        'pom-file': str(pom_file_path)
+                        'pom-file': 'does-not-exist.pom'
                     }
                 }
             }
         }
         factory = TSSCFactory(config)
-        with pytest.raises(ValueError):
+        with self.assertRaisesRegex(
+                ValueError, 
+                'Given pom file does not exist: does-not-exist.pom'):
             factory.run_step('package')
-
-def test_pom_file_valid_old_empty_jar ():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>42.1</version>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+    
+    @patch('sh.mvn', create=True)
+    def test_config_file_pom_file_none_value(self, mvn_mock):
         config = {
             'tssc-config': {
                 'package': {
                     'implementer': 'Maven',
                     'config': {
-                        'pom-file': str(pom_file_path)
-                    }
-                }
-            }
-        }
-        expected_step_results = {
-            'tssc-results': {
-                'package': {
-                    'artifacts': [{
-                        'path': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar'),
-                        'artifact-id': 'my-app',
-                        'group-id': 'com.mycompany.app',
-                        'package-type': 'jar',
-                        'pom-path': str(pom_file_path)
-                    }]
-                }
-            }
-        }
-
-        run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
-
-def test_pom_file_valid_with_namespace_empty_jar ():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('pom.xml',b'''<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>42.1</version>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
-        results_dir_path = os.path.join(temp_dir.path, 'tssc-resutls')
-
-        config = {
-            'tssc-config': {
-                'package': {
-                    'implementer': 'Maven',
-                    'config': {
-                        'pom-file': str(pom_file_path)
-                    }
-                }
-            }
-        }
-        expected_step_results = {
-            'tssc-results': {
-                'package': {
-                    'artifacts': [{
-                        'path': os.path.join(temp_dir.path, 'target', 'my-app-42.1.jar'),
-                        'artifact-id': 'my-app',
-                        'group-id': 'com.mycompany.app',
-                        'package-type': 'jar',
-                        'pom-path': str(pom_file_path)
-                    }]
-                }
-            }
-        }
-        run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
-
-def test_mvn_quickstart_single_jar_java_error():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
-public class Fail {
-    public static void main( String[] args ) {
-        System.out.println( "Hello World!" );
-    }
-}''')
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-    <version>1.0-SNAPSHOT</version>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
-        config = {
-            'tssc-config': {
-                'package': {
-                    'implementer': 'Maven',
-                    'config': {
-                        'pom-file': str(pom_file_path)
+                        'pom-file': None
                     }
                 }
             }
         }
         factory = TSSCFactory(config)
-        with pytest.raises(ValueError):
+        with self.assertRaisesRegex(
+                ValueError, 
+                r'Key \(pom-file\) must have none empty value in the step configuration'):
             factory.run_step('package')
-
-def test_pom_file_missing_version ():
-    with TempDirectory() as temp_dir:
-        temp_dir.write('pom.xml',b'''<project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.mycompany.app</groupId>
-    <artifactId>my-app</artifactId>
-</project>''')
-        pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
-
-        config = {
-            'tssc-config': {
-                'package': {
-                    'implementer': 'Maven',
-                    'config': {
-                        'pom-file': str(pom_file_path)
+    
+    @patch('sh.mvn', create=True, side_effect = sh.ErrorReturnCode('mvn clean install', b'mock out', b'mock error'))
+    def test_mvn_error_return_code(self, mvn_mock):
+        artifact_id = 'my-app'
+        version = '1.0'
+        package = 'jar'
+        with TempDirectory() as temp_dir:
+            temp_dir.write('src/main/java/com/mycompany/app/App.java',b'''package com.mycompany.app;
+    public class App {
+        public static void main( String[] args ) {
+            System.out.println( "Hello World!" );
+        }
+    }''')
+            temp_dir.write(
+                'pom.xml',
+                bytes('''<project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.mycompany.app</groupId>
+        <artifactId>{artifact_id}</artifactId>
+        <version>{version}</version>
+        <properties>
+            <maven.compiler.source>1.8</maven.compiler.source>
+            <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
+    </project>'''.format(artifact_id=artifact_id, version=version), 'utf-8')
+            )
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            config = {
+                'tssc-config': {
+                    'package': {
+                        'implementer': 'Maven',
+                        'config': {
+                            'pom-file': str(pom_file_path)
+                        }
                     }
                 }
             }
-        }
-        factory = TSSCFactory(config)
-        with pytest.raises(ValueError):
-            factory.run_step('package')
-
-def test_default_pom_file_missing ():
-    config = {
-        'tssc-config': {
-            'package': {
-                'implementer': 'Maven'
-            }
-        }
-    }
-    factory = TSSCFactory(config)
-    with pytest.raises(ValueError):
-        factory.run_step('package', {'pom-file': 'does-not-exist-pom.xml'})
-
-def test_runtime_pom_file_missing ():
-    config = {
-        'tssc-config': {
-            'package': {
-                'implementer': 'Maven'
-            }
-        }
-    }
-    factory = TSSCFactory(config)
-    with pytest.raises(ValueError):
-        factory.run_step('package', {'pom-file': 'does-not-exist-pom.xml'})
-
-def test_config_file_pom_file_missing ():
-    config = {
-        'tssc-config': {
-            'package': {
-                'implementer': 'Maven',
-                'config': {
-                    'pom-file': 'does-not-exist.pom'
+            artfiact_file_name = '{artifact_id}-{version}.{package}'.format(
+                artifact_id=artifact_id,
+                version=version,
+                package=package
+            )
+            expected_step_results = {
+                'tssc-results': {
+                    'package': {
+                        'artifacts': [{
+                            'path': os.path.join(
+                                temp_dir.path,
+                                'target',
+                                artfiact_file_name
+                            ),
+                            'artifact-id': artifact_id,
+                            'group-id': 'com.mycompany.app',
+                            'pom-path': str(pom_file_path),
+                            'package-type': 'jar'
+                        }]
+                    }
                 }
             }
-        }
-    }
-    factory = TSSCFactory(config)
-    with pytest.raises(ValueError):
-        factory.run_step('package')
-
-def test_config_file_pom_file_none_value ():
-    config = {
-        'tssc-config': {
-            'package': {
-                'implementer': 'Maven',
-                'config': {
-                    'pom-file': None
-                }
-            }
-        }
-    }
-    factory = TSSCFactory(config)
-    with pytest.raises(ValueError):
-        factory.run_step('package')
+            
+            with self.assertRaisesRegex(
+                    RuntimeError, 
+                    'Error invoking mvn:.*'):
+                run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)

--- a/tests/step_implementers/tag_source/test_git.py
+++ b/tests/step_implementers/tag_source/test_git.py
@@ -1,14 +1,6 @@
-import os
-
-import pytest
 from testfixtures import TempDirectory
-import yaml
 import unittest
 from unittest.mock import patch
-from tssc.step_implementers.tag_source.git import Git
-
-from tssc import TSSCFactory
-from tssc.step_implementers.tag_source import Git
 
 from test_utils import *
 


### PR DESCRIPTION
- tssc/step_implementers/package/maven.py - update to use sh rather then subprocess
- tests/step_implementers/package/test_maven_package.py - update to use unittest.TestCase and mocks for sh.mvn
- tests/step_implementers/package/test_maven_package.py - update to check for specific error messages