### PR TITLE
NAPSSPO-552 - update test_buildah and test_skopeo to use mocks

### DIFF
--- a/tests/step_implementers/create_container_image/test_buildah.py
+++ b/tests/step_implementers/create_container_image/test_buildah.py
@@ -1,36 +1,29 @@
 import os
+import sh
+import sys
 
-import pytest
+import unittest
+from unittest.mock import patch
 from testfixtures import TempDirectory
-import yaml
 
-from tssc import TSSCFactory
 from tssc.step_implementers.create_container_image import Buildah
 
 from test_utils import *
 
-def test_create_container_image_default():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+class TestStepImplementerCreateContaienrImageBuildah(unittest.TestCase):
+    def test_create_container_image_default(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {}
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': ''}}}
-
-            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except ValueError as err:
-             if (err.__str__() == 'Key (tag) must have non-empty value in the step configuration'):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+            
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r'Key \(tag\) must have non-empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    def test_create_container_image_specify_buildah_implementer(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {    
                     'create-container-image': {
@@ -39,20 +32,14 @@ def test_create_container_image_specify_buildah_implementer():
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': ''}}}
-
-            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except ValueError as err:
-            if (err.__str__() == 'Key (tag) must have non-empty value in the step configuration'):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer_missing_config():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+    
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r'Key \(tag\) must have non-empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    def test_create_container_image_specify_buildah_implementer_missing_config(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {    
                     'create-container-image': {
@@ -64,20 +51,14 @@ def test_create_container_image_specify_buildah_implementer_missing_config():
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test'}}}
 
-            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except ValueError as err:
-            if (err.__str__()  == 'Key (tlsverify) must have non-empty value in the step configuration'):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer_with_tag_no_dockerfile():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r'Key \(tlsverify\) must have non-empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    def test_create_container_image_specify_buildah_implementer_with_tag_no_dockerfile(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {    
                     'create-container-image': {
@@ -89,21 +70,16 @@ def test_create_container_image_specify_buildah_implementer_with_tag_no_dockerfi
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test'}}}
 
-            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except ValueError as err:
-            if (err.__str__().startswith('Image specification file does not exist in location')):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer_with_tag_invalid_dockerfile():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        temp_dir.write('Dockerfile',b'Invalid Dockerfile')
-        try:
+            with self.assertRaisesRegex(
+                    ValueError,
+                    'Image specification file does not exist in location'):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    @patch('sh.buildah', create=True)
+    def test_create_container_image_specify_buildah_implementer_with_tag_invalid_dockerfile(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.write('Dockerfile',b'Invalid Dockerfile')
             config = {
                 'tssc-config': {    
                     'create-container-image': {
@@ -115,76 +91,99 @@ def test_create_container_image_specify_buildah_implementer_with_tag_invalid_doc
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test'}}}
 
-            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except RuntimeError as err:
-            if (err.__str__().startswith('Issue invoking')):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile():
-
-    with TempDirectory() as temp_dir:
-        temp_dir.write('Dockerfile',b'FROM registry.access.redhat.com/ubi8:latest')
-        config = {
-            'tssc-config': {    
-                'create-container-image': {
-                    'implementer': 'Buildah',
-                    'config': {
-                        'tag' : 'localhost:test',
-                        'context' : temp_dir.path
+            sh.buildah.bud.side_effect = sh.ErrorReturnCode('buildah bud', b'mock stdout', b'mock error about invalid dockerfile')
+            with self.assertRaisesRegex(
+                    RuntimeError,
+                    r'Issue invoking buildah bud with given image specification file \(Dockerfile\)'):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    @patch('sh.buildah', create=True)
+    def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            tag = 'localhost:test'
+            file = 'Dockerfile'
+            temp_dir.write(file,b'FROM registry.access.redhat.com/ubi8:latest')
+            config = {
+                'tssc-config': {    
+                    'create-container-image': {
+                        'implementer': 'Buildah',
+                        'config': {
+                            'tag' : tag,
+                            'context' : temp_dir.path
+                        }
                     }
                 }
             }
-        }
-        expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test'}}}
-        run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-
-def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile_as_tarfile_fail():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        temp_dir.write('Dockerfile',b'FROM registry.access.redhat.com/ubi8:latest')
-        config = {
-            'tssc-config': {    
-                'create-container-image': {
-                    'implementer': 'Buildah',
-                    'config': {
-                        'tag' : 'localhost:test',
-                        'context' : temp_dir.path,
-                        'image_tar_file' : '/nonexistentpath/image.tar'
-                    }
-                }
-            }
-        }
-
-        try:
             expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test'}}}
             run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        except RuntimeError as err:
-            if (err.__str__().startswith('Issue invoking')):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile_as_tarfile_success():
-
-    with TempDirectory() as temp_dir:
-        temp_dir.write('Dockerfile',b'FROM registry.access.redhat.com/ubi8:latest')
-        config = {
-            'tssc-config': {    
-                'create-container-image': {
-                    'implementer': 'Buildah',
-                    'config': {
-                        'tag' : 'localhost:test',
-                        'context' : temp_dir.path,
-                        'image_tar_file' : temp_dir.path + '/image.tar'
+            buildah_mock.bud.assert_called_once_with(
+                '--format=oci',
+                '--tls-verify=true',
+                '--layers',
+                '-f', file,
+                '-t', tag,
+                temp_dir.path,
+                _out=sys.stdout
+            )
+            buildah_mock.push.assert_not_called()
+    
+    @patch('sh.buildah', create=True)
+    def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile_as_tarfile_fail(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            image_tar_file = '/nonexistentpath/image.tar'
+            temp_dir.write('Dockerfile',b'FROM registry.access.redhat.com/ubi8:latest')
+            config = {
+                'tssc-config': {    
+                    'create-container-image': {
+                        'implementer': 'Buildah',
+                        'config': {
+                            'tag' : 'localhost:test',
+                            'context' : temp_dir.path,
+                            'image_tar_file' : image_tar_file
+                        }
                     }
                 }
             }
-        }
-        expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test', 'image_tar_file' : temp_dir.path + '/image.tar'}}}
-        run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
-        assert os.path.exists(temp_dir.path + '/image.tar')
+            
+            sh.buildah.push.side_effect = sh.ErrorReturnCode('buildah bud', b'mock stdout', b'mock error about invalid image tar file')
+            with self.assertRaisesRegex(
+                    RuntimeError,
+                    r'Issue invoking buildah push to tar file {image_tar_file}'.format(image_tar_file=image_tar_file)):
+                run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
+    
+    @patch('sh.buildah', create=True)
+    def test_create_container_image_specify_buildah_implementer_with_tag_valid_dockerfile_as_tarfile_success(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            tag = 'localhost:test'
+            file = 'Dockerfile'
+            image_tar_file = temp_dir.path + '/image.tar'
+            temp_dir.write(file,b'FROM registry.access.redhat.com/ubi8:latest')
+            config = {
+                'tssc-config': {    
+                    'create-container-image': {
+                        'implementer': 'Buildah',
+                        'config': {
+                            'tag' : tag,
+                            'context' : temp_dir.path,
+                            'image_tar_file' : image_tar_file
+                        }
+                    }
+                }
+            }
+            expected_step_results = {'tssc-results': {'create-container-image': {'image_tag': 'localhost:test', 'image_tar_file' : temp_dir.path + '/image.tar'}}}
+            run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
+            buildah_mock.bud.assert_called_once_with(
+                '--format=oci',
+                '--tls-verify=true',
+                '--layers',
+                '-f', file,
+                '-t', tag,
+                temp_dir.path,
+                _out=sys.stdout
+            )
+            buildah_mock.push.assert_called_once_with(
+                tag,
+                'docker-archive:{image_tar_file}'.format(image_tar_file=image_tar_file),
+                _out=sys.stdout
+            )

--- a/tests/step_implementers/push_container_image/test_skopeo.py
+++ b/tests/step_implementers/push_container_image/test_skopeo.py
@@ -1,37 +1,30 @@
-import os
+import sh
+import sys
 
-import pytest
+import unittest
+from unittest.mock import patch
 from testfixtures import TempDirectory
-import yaml
 
-from tssc import TSSCFactory
 from tssc.step_implementers.push_container_image import Skopeo
 
 from test_utils import *
 
-def test_create_container_image_default_missing_args():
+class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
 
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+    def test_create_container_image_default_missing_args(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {}
             }
             expected_step_results = {'tssc-results': {'push-container-image': {'image_tag': ''}}}
-
-            run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
-        except ValueError as err:
-             if (err.__str__() == 'Key (source) must have non-empty value in the step configuration' or
-                 err.__str__() == 'Key (destination) must have non-empty value in the step configuration'):
-                passed = True
-
-    assert passed
-
-def test_push_container_image_specify_skopeo_implementer_missing_args():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+    
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r'Key \(source\) must have non-empty value in the step configuration|Key \(destination\) must have non-empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
+    
+    def test_push_container_image_specify_skopeo_implementer_missing_args(self):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {    
                     'push-container-image': {
@@ -42,19 +35,14 @@ def test_push_container_image_specify_skopeo_implementer_missing_args():
             }
             expected_step_results = {'tssc-results': {'push-container-image': {'image_tag': ''}}}
 
-            run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
-        except ValueError as err:
-             if (err.__str__() == 'Key (source) must have non-empty value in the step configuration' or
-                 err.__str__() == 'Key (destination) must have non-empty value in the step configuration'):
-                passed = True
-
-    assert passed
-
-def test_create_container_image_specify_skopeo_implementer_invalid_arguments():
-
-    passed = False
-    with TempDirectory() as temp_dir:
-        try:
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r'Key \(source\) must have non-empty value in the step configuration|Key \(destination\) must have non-empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
+    
+    @patch('sh.skopeo', create=True)
+    def test_create_container_image_specify_skopeo_implementer_invalid_arguments(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {    
                     'push-container-image': {
@@ -66,63 +54,80 @@ def test_create_container_image_specify_skopeo_implementer_invalid_arguments():
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'push-container-image': {'image_tag': 'docker-archive:' + temp_dir.path + '/image.tar:latest'}}}
-
-            run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
-        except RuntimeError as err:
-            if (err.__str__().startswith('Error invoking')):
-                passed = True
-
-    assert passed
-
-
-def test_create_container_image_specify_skopeo_implementer_valid_arguments():
-
-    with TempDirectory() as temp_dir:
-        config = {
-            'tssc-config': {    
-                'push-container-image': {
-                    'implementer': 'Skopeo',
-                    'config': {
-                        'source' : 'docker://quay.io/tssc/tssc-base:latest',
-                        'destination' : 'docker-archive:' + temp_dir.path + '/image.tar' 
+    
+            sh.skopeo.copy.side_effect = sh.ErrorReturnCode('skopeo copy', b'mock stdout', b'mock error about bogus transport')
+            with self.assertRaisesRegex(
+                    RuntimeError,
+                    r'Error invoking skopeo: .*'):
+                run_step_test_with_result_validation(temp_dir, 'push-container-image', config, [])
+    
+    @patch('sh.skopeo', create=True)
+    def test_create_container_image_specify_skopeo_implementer_valid_arguments(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            source = 'docker://quay.io/tssc/tssc-base:latest'
+            destination = 'docker-archive:{path}/image.tar'.format(path=temp_dir.path)
+            config = {
+                'tssc-config': {    
+                    'push-container-image': {
+                        'implementer': 'Skopeo',
+                        'config': {
+                            'source' : source,
+                            'destination' : destination
+                        }
                     }
                 }
             }
-        }
-        expected_step_results = {'tssc-results': {'push-container-image': {'image_tag': 'docker-archive:' + temp_dir.path + '/image.tar:latest'}}}
-        run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
+            
+            expected_step_results = {'tssc-results': {'push-container-image': {'image_tag': "{destination}:{version}".format(destination=destination, version='latest')}}}
+            run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
+            skopeo_mock.copy.assert_called_once_with(
+                '--src-tls-verify=true',
+                '--dest-tls-verify=true',
+                source,
+                "{destination}:{version}".format(destination=destination, version='latest'),
+                _out=sys.stdout
+            )
 
-
-def test_create_container_image_specify_skopeo_implementer_valid_arguments_passed_in_with_metadata_version():
-    with TempDirectory() as temp_dir:
-
-        temp_dir.makedir('tssc-results')
-        temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
-          generate-metadata:
-            image-tag: 1.0-SNAPSHOT-69442c8
-            ''')
-
-        config = {
-            'tssc-config': {    
-                'push-container-image': {
-                    'implementer': 'Skopeo',
-                    'config': {
-                        'source' : 'docker://quay.io/tssc/tssc-base:latest',
-                        'destination' : 'docker-archive:' + temp_dir.path + '/image.tar' 
+    @patch('sh.skopeo', create=True)
+    def test_create_container_image_specify_skopeo_implementer_valid_arguments_passed_in_with_metadata_version(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            source = 'docker://quay.io/tssc/tssc-base:latest'
+            destination = 'docker-archive:{path}/image.tar'.format(path=temp_dir.path)
+            version = '1.0-69442c8'
+            temp_dir.makedir('tssc-results')
+            temp_dir.write(
+                'tssc-results/tssc-results.yml',
+                bytes(
+                    '''tssc-results:
+                  generate-metadata:
+                    image-tag: {version}
+                '''.format(version=version),
+                    'utf-8')
+                )
+    
+            config = {
+                'tssc-config': {    
+                    'push-container-image': {
+                        'implementer': 'Skopeo',
+                        'config': {
+                            'source' : source,
+                            'destination' : destination
+                        }
                     }
-                }
-            },
-            'generate-metadata': {
-                    'implementer': 'Maven',
-                    'config' : {}
-                }
-        }
-
-        print(os.listdir(temp_dir.path+'/tssc-results'))
-
-        expected_step_results = {'tssc-results': {'generate-metadata': {'image-tag': '1.0-SNAPSHOT-69442c8'},
-                                 'push-container-image': {'image_tag':'docker-archive:' + temp_dir.path + 
-                                 '/image.tar:1.0-snapshot-69442c8'}}}
-        run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
-
+                },
+                'generate-metadata': {
+                        'implementer': 'Maven',
+                        'config' : {}
+                    }
+            }
+    
+            expected_step_results = {'tssc-results': {'generate-metadata': {'image-tag': version},
+                                     'push-container-image': {'image_tag':"{destination}:{version}".format(destination=destination, version=version)}}}
+            run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
+            skopeo_mock.copy.assert_called_once_with(
+                '--src-tls-verify=true',
+                '--dest-tls-verify=true',
+                source,
+                "{destination}:{version}".format(destination=destination, version=version),
+                _out=sys.stdout
+            )

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -73,10 +73,8 @@ class Buildah(StepImplementer):
             raise ValueError('Image specification file does not exist in location: '
                              + image_spec_file_location)
 
-        buildah_bud = sh.buildah.bake("bud")  # pylint: disable=no-member
-
         try:
-            print(buildah_bud(
+            print(sh.buildah.bud( #pylint: disable=no-member
                 '--format=' + runtime_step_config['format'],
                 '--tls-verify=' + runtime_step_config['tlsverify'],
                 '--layers', '-f', image_spec_file,
@@ -85,7 +83,7 @@ class Buildah(StepImplementer):
                 _out=sys.stdout
             ))
         except sh.ErrorReturnCode:  # pylint: disable=undefined-variable
-            raise RuntimeError('Issue invoking buildah bud  with given image '
+            raise RuntimeError('Issue invoking buildah bud with given image '
                                'specification file (' + image_spec_file + ')')
 
         results = {
@@ -93,18 +91,16 @@ class Buildah(StepImplementer):
         }
 
         if 'image_tar_file' in runtime_step_config and runtime_step_config['image_tar_file']:
-
             image_tar_file = runtime_step_config['image_tar_file']
-            rm_f = sh.rm.bake("-f") # pylint: disable=no-member
-            print(rm_f(image_tar_file))
-
-            buildah_push = sh.buildah.bake("push") # pylint: disable=no-member
+            print(sh.rm('-f', image_tar_file)) #pylint: disable=no-member
             try:
-                print(buildah_push(
-                    tag,
-                    "docker-archive:" + image_tar_file,
-                    _out=sys.stdout
-                ))
+                print(
+                    sh.buildah.push( #pylint: disable=no-member
+                        tag,
+                        "docker-archive:" + image_tar_file,
+                        _out=sys.stdout
+                    )
+                )
             except sh.ErrorReturnCode:  # pylint: disable=undefined-variable
                 raise RuntimeError('Issue invoking buildah push to tar file ' + image_tar_file)
 

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -63,16 +63,18 @@ class Skopeo(StepImplementer):
         else:
             print('No version found in metadata. Using latest')
 
-        destination_with_version = (runtime_step_config['destination'] + ':' + version).lower()
-        skopeo_copy = sh.skopeo.bake("copy") # pylint: disable=no-member
+        destination_with_version = runtime_step_config['destination'] + ':' + (version).lower()
         try:
-            print(skopeo_copy(
-                '--src-tls-verify=' + runtime_step_config['src-tls-verify'],
-                '--dest-tls-verify=' + runtime_step_config['dest-tls-verify'],
-                runtime_step_config['source'],
-                destination_with_version, _out=sys.stdout))
-        except sh.ErrorReturnCode:  # pylint: disable=undefined-variable
-            raise RuntimeError('Error invoking skopeo')
+            print(
+                sh.skopeo.copy( #pylint: disable=no-member
+                    '--src-tls-verify=' + runtime_step_config['src-tls-verify'],
+                    '--dest-tls-verify=' + runtime_step_config['dest-tls-verify'],
+                    runtime_step_config['source'],
+                    destination_with_version, _out=sys.stdout
+                )
+            )
+        except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
+            raise RuntimeError('Error invoking skopeo: {error}'.format(error=error))
 
         results = {
             'image_tag' : destination_with_version


### PR DESCRIPTION
-    tssc/step_implementers/push_container_image/skopeo.py - only lowercase version not entire path
-    tests/step_implementers/push_container_image/test_skopeo.py - update to use mock