### PR TITLE
NAPSSPO-486 add runtime arguments for user and password

### DIFF
--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -1,3 +1,4 @@
+import sh
 import os
 
 import pytest
@@ -26,57 +27,63 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestohollywood',
                         }
                     }
                 }
             }
+            runtime_args = {
+                'user': 'unit.test.user',
+                'password': 'unit.test.password'
+            }
             expected_step_results = {}
             with self.assertRaisesRegex(
                     ValueError,
-                    'Key \(url\) must have none empty value in the step configuration'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                    'url must have none empty value in the step configuration'):
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
-    def test_push_artifact_with_user_missing_from_config(self, mvn_mock):
+    def test_push_artifact_with_user_missing_from_runtime(self, mvn_mock):
         with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'password': 'goestohollywood',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                      }
                  }
             }
+            runtime_args = {
+                'password': 'unit.test.password',
+            }
             expected_step_results = {}
             with self.assertRaisesRegex(
                     ValueError,
-                    'Key \(user\) must have none empty value in the step configuration'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                    'Either user or password is not set. Neither or both must be set.'):
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
-    def test_push_artifact_with_password_missing_from_config(self, mvn_mock):
+    def test_push_artifact_with_password_missing_from_runtime(self, mvn_mock):
         with TempDirectory() as temp_dir:
             config = {
                 'tssc-config': {
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
                 }
             }
+            runtime_args = {
+                'user': 'unit.test.user',
+            }
             expected_step_results = {}
             with self.assertRaisesRegex(
                     ValueError,
-                    'Key \(password\) must have none empty value in the step configuration'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                    'Either user or password is not set. Neither or both must be set.'):
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
     # ------------  Tests that require generate-metadata 
     @patch('sh.mvn', create=True)
@@ -92,18 +99,20 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestohollywood',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
                 }
             }
+            runtime_args = {
+                'user': 'unit.test.user',
+                'password': 'unit.test.password'
+            }
             expected_step_results = {}
             with self.assertRaisesRegex(
                     ValueError,
                     'Severe error: Generate-metadata does not have a version'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
     def test_push_artifact_with_artifacts_missing_from_results(self, mvn_mock):
@@ -118,18 +127,20 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestoholloywood',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
                 }
             }
+            runtime_args = {
+                'user': 'user',
+                'password': 'password'
+            }
             expected_step_results = {}
             with self.assertRaisesRegex(
                     ValueError,
                     'Severe error: Package does not have artifacts'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
 
     @patch('sh.mvn', create=True)
@@ -156,8 +167,76 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestohollywood',
+                            'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
+                        }
+                    }
+                 }
+            }
+            runtime_args = {
+                'user': 'unit.test.user',
+                'password': 'unit.test.password'
+            }
+            expected_step_results = {
+                'tssc-results': 
+                    {
+                        'generate-metadata': 
+                        {
+                            'version': '1.0-123abc'
+                        }, 
+                        'package': 
+                        {
+                            'artifacts': 
+                            [
+                                {
+                                    'artifact-id': 'my-app', 
+                                    'group-id': 'com.mycompany.app', 
+                                    'package-type': 'jar', 
+                                    'path': str(jar_file_path), 
+                                    'pom-path': 'pom.xml'
+                                }
+                             ]
+                        },
+                        'push-artifacts': 
+                        {
+                            'artifacts': 
+                            [
+                                {
+                                    'artifact-id': 'my-app', 
+                                    'group-id': 'com.mycompany.app', 
+                                    'path': str(jar_file_path), 
+                                    'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc//com/mycompany/app/my-app/1.0-123abc/my-app-1.0-123abc.jar', 
+                                    'version': '1.0-123abc'
+                                }
+                            ]
+                        }
+                    }
+            }
+
+            run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
+    @patch('sh.mvn', create=True)
+    def test_push_artifact_with_no_user_password_results(self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            temp_dir.makedir('target')
+            temp_dir.write('target/my-app-1.0-SNAPSHOT.jar', b'''sandbox''')
+            jar_file_path = os.path.join(temp_dir.path, 'target/my-app-1.0-SNAPSHOT.jar')
+            tssc_results='''tssc-results:
+                generate-metadata:
+                    version: 1.0-123abc
+                package:
+                    'artifacts': [{
+                        'path':'''+ str(jar_file_path)+''',
+                        'artifact-id': 'my-app',
+                        'group-id': 'com.mycompany.app',
+                        'package-type': 'jar',
+                        'pom-path': 'pom.xml'
+                    }]
+            '''
+            temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
+            config = {
+                'tssc-config': {
+                    'push-artifacts': {
+                        'implementer': 'Maven',
+                        'config': {
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
@@ -201,7 +280,7 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
 
             run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
 
-    @patch('sh.mvn', create=True, return_value='99', side_effect=Exception('Test'))
+    @patch('sh.mvn', create=True)
     def test_push_artifact_with_artifacts_results_bad(self, mock_mvn):
 
         with TempDirectory() as temp_dir:
@@ -221,13 +300,15 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     }]
             '''
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
+            runtime_args = {
+                'user': 'unit.test.user',
+                'password': 'unit.test.password'
+            }
             config = {
                 'tssc-config': {
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestohollywood',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
@@ -269,10 +350,11 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     }
             }
             expected_step_results = {}
+            sh.mvn.side_effect = sh.ErrorReturnCode('mvn', b'mock stdout', b'mock error')
             with self.assertRaisesRegex(
-                    ValueError,
+                    RuntimeError,
                     'Error invoking mvn'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+                run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
     def test_push_artifact_with_artifacts_results_multi(self, mvn_mock):
@@ -305,12 +387,14 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     'push-artifacts': {
                         'implementer': 'Maven',
                         'config': {
-                            'user': 'frankie',
-                            'password': 'goestohollywood',
                             'url': 'http://artifactory.apps.tssc.rht-set.com/artifactory/tssc/',
                         }
                     }
                  }
+            }
+            runtime_args = {
+                'user': 'unit.test.user',
+                'password': 'unit.test.password'
             }
             expected_step_results = {
                 'tssc-results': 
@@ -362,4 +446,5 @@ class TestStepImplementerPushArtifact(unittest.TestCase):
                     }
             }
 
-            run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results)
+            run_step_test_with_result_validation(temp_dir, 'push-artifacts', config, expected_step_results, runtime_args)
+


### PR DESCRIPTION
Fixed a design flaw - changed user/password to use the runtime_args = {} instead of config args.
Added unit tests.
Tested on Jenkins using a Global Credential.