### PR TITLE
Feature/napsspo 558 added organization

### DIFF
--- a/tests/step_implementers/push_container_image/test_skopeo.py
+++ b/tests/step_implementers/push_container_image/test_skopeo.py
@@ -15,29 +15,33 @@ class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
         with TempDirectory() as temp_dir:
             application_name = 'foo'
             service_name = 'bar'
+            organization = 'xyzzy'
             config = {
                 'tssc-config': {
                     'global-defaults': {
                         'application-name': application_name,
-                        'service-name': service_name
+                        'service-name': service_name,
+                        'organization': organization
                     }
                 }
             }
             expected_step_results = {'tssc-results': {'push-container-image': {'image-tag': ''}}}
             with self.assertRaisesRegex(
                     AssertionError,
-                    r'The runtime step configuration \(\{\'src-tls-verify\': \'true\', \'dest-tls-verify\': \'true\', \'application-name\': \'foo\', \'service-name\': \'bar\'\}\) is missing the required configuration keys \(\[\'destination\'\]\)'):
+                    r'The runtime step configuration \(\{\'src-tls-verify\': \'true\', \'dest-tls-verify\': \'true\', \'application-name\': \'foo\', \'service-name\': \'bar\', \'organization\': \'xyzzy\'\}\) is missing the required configuration keys \(\[\'destination-url\'\]\)'):
                 run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
 
     def test_push_container_image_specify_skopeo_implementer_missing_args(self):
         with TempDirectory() as temp_dir:
             application_name = 'foo'
             service_name = 'bar'
+            organization = 'xyzzy'
             config = {
                 'tssc-config': {
                     'global-defaults': {
                         'application-name': application_name,
-                        'service-name': service_name
+                        'service-name': service_name,
+                        'organization': organization
                     },
                     'push-container-image': {
                         'implementer': 'Skopeo',
@@ -49,7 +53,7 @@ class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
 
             with self.assertRaisesRegex(
                     AssertionError,
-                    r'The runtime step configuration \(\{\'src-tls-verify\': \'true\', \'dest-tls-verify\': \'true\', \'application-name\': \'foo\', \'service-name\': \'bar\'\}\) is missing the required configuration keys \(\[\'destination\'\]\)'):
+                    r'The runtime step configuration \(\{\'src-tls-verify\': \'true\', \'dest-tls-verify\': \'true\', \'application-name\': \'foo\', \'service-name\': \'bar\', \'organization\': \'xyzzy\'\}\) is missing the required configuration keys \(\[\'destination-url\'\]\)'):
                 run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
 
     @patch('sh.skopeo', create=True)
@@ -57,16 +61,18 @@ class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
         with TempDirectory() as temp_dir:
             application_name = 'foo'
             service_name = 'bar'
+            organization = 'xyzzy'
             config = {
                 'tssc-config': {
                     'global-defaults': {
                         'application-name': application_name,
-                        'service-name': service_name
+                        'service-name': service_name,
+                        'organization': organization
                     },
                     'push-container-image': {
                         'implementer': 'Skopeo',
                         'config': {
-                            'destination' : 'docker-archive:' + temp_dir.path + '/image.tar'
+                            'destination-url' : 'docker-archive:' + temp_dir.path + '/image.tar'
                         }
                     }
                 }
@@ -97,28 +103,30 @@ class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
                 )
             application_name = 'foo'
             service_name = 'bar'
+            organization = 'xyzzy'
             config = {
                 'tssc-config': {
                     'global-defaults': {
                         'application-name': application_name,
-                        'service-name': service_name
+                        'service-name': service_name,
+                        'organization': organization
                     },
                     'push-container-image': {
                         'implementer': 'Skopeo',
                         'config': {
                             'source' : source,
-                            'destination' : destination
+                            'destination-url' : destination
                         }
                     }
                 }
             }
-            expected_step_results = {'tssc-results': { 'create-container-image': {'image-tar-file': destination}, 'generate-metadata': {'image-tag': version }, 'push-container-image': {'image-tag': "{destination}/{application_name}/{service_name}:{version}".format(destination=destination, application_name=application_name, service_name=service_name, version=version)}}}
+            expected_step_results = {'tssc-results': { 'create-container-image': {'image-tar-file': destination}, 'generate-metadata': {'image-tag': version }, 'push-container-image': {'image-tag': "{destination}/{organization}/{application_name}-{service_name}:{version}".format(destination=destination, organization=organization, application_name=application_name, service_name=service_name, version=version)}}}
             run_step_test_with_result_validation(temp_dir, 'push-container-image', config, expected_step_results)
             skopeo_mock.copy.assert_called_once_with(
                 '--src-tls-verify=true',
                 '--dest-tls-verify=true',
                 "docker-archive:{destination}".format(destination=destination),
-                "{destination}/{application_name}/{service_name}:{version}".format(destination=destination, application_name=application_name, service_name=service_name, version=version),
+                "{destination}/{organization}/{application_name}-{service_name}:{version}".format(destination=destination, organization=organization, application_name=application_name, service_name=service_name, version=version),
                 _out=sys.stdout
             )
 
@@ -143,17 +151,19 @@ class TestStepImplementerPushContainerImageSkopeo(unittest.TestCase):
 
             application_name = 'foo'
             service_name = 'bar'
+            organization = 'xyzzy'
             config = {
                 'tssc-config': {
                     'global-defaults': {
                         'application-name': application_name,
-                        'service-name': service_name
+                        'service-name': service_name,
+                        'organization': organization
                     },
                     'push-container-image': {
                         'implementer': 'Skopeo',
                         'config': {
                             'source' : source,
-                            'destination' : destination
+                            'destination-url' : destination
                         }
                     }
                 },

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -47,7 +47,9 @@ DEFAULT_CONFIG = {
 REQUIRED_CONFIG_KEYS = [
     'destination',
     'src-tls-verify',
-    'dest-tls-verify'
+    'dest-tls-verify',
+    'service-name',
+    'application-name'
 ]
 
 class Skopeo(StepImplementer):
@@ -121,6 +123,9 @@ class Skopeo(StepImplementer):
         else:
             print('No version found in metadata. Using latest')
 
+        application_name = runtime_step_config['application-name']
+        service_name = runtime_step_config['service-name']
+
         image_tar_file = ''
         if(self.get_step_results(DefaultSteps.CREATE_CONTAINER_IMAGE) and \
           self.get_step_results(DefaultSteps.CREATE_CONTAINER_IMAGE).get('image-tar-file')):
@@ -129,7 +134,8 @@ class Skopeo(StepImplementer):
         else:
             raise RuntimeError('Missing image tar file from ' + DefaultSteps.CREATE_CONTAINER_IMAGE)
 
-        destination_with_version = runtime_step_config['destination'] + ':' + (version).lower()
+        destination_with_version = runtime_step_config['destination'] + '/' + \
+          application_name + '/' + service_name + ':' + (version).lower()
         try:
             print(
                 sh.skopeo.copy( #pylint: disable=no-member

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -45,11 +45,12 @@ DEFAULT_CONFIG = {
 }
 
 REQUIRED_CONFIG_KEYS = [
-    'destination',
+    'destination-url',
     'src-tls-verify',
     'dest-tls-verify',
     'service-name',
-    'application-name'
+    'application-name',
+    'organization'
 ]
 
 class Skopeo(StepImplementer):
@@ -125,6 +126,7 @@ class Skopeo(StepImplementer):
 
         application_name = runtime_step_config['application-name']
         service_name = runtime_step_config['service-name']
+        organization = runtime_step_config['organization']
 
         image_tar_file = ''
         if(self.get_step_results(DefaultSteps.CREATE_CONTAINER_IMAGE) and \
@@ -134,8 +136,7 @@ class Skopeo(StepImplementer):
         else:
             raise RuntimeError('Missing image tar file from ' + DefaultSteps.CREATE_CONTAINER_IMAGE)
 
-        destination_with_version = runtime_step_config['destination'] + '/' + \
-          application_name + '/' + service_name + ':' + (version).lower()
+        destination_with_version = runtime_step_config['destination-url'] + '/' + organization + '/' + application_name + '-' + service_name + ':' + (version).lower()
         try:
             print(
                 sh.skopeo.copy( #pylint: disable=no-member

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -136,8 +136,8 @@ class Skopeo(StepImplementer):
         else:
             raise RuntimeError('Missing image tar file from ' + DefaultSteps.CREATE_CONTAINER_IMAGE)
 
-        destination_with_version = runtime_step_config['destination-url'] + '/' + organization + '/' \
-          + application_name + '-' + service_name + ':' + (version).lower()
+        destination_with_version = runtime_step_config['destination-url'] + '/' + organization + \
+         '/' + application_name + '-' + service_name + ':' + (version).lower()
         try:
             sh.skopeo.copy( # pylint: disable=no-member
                 '--src-tls-verify=' + runtime_step_config['src-tls-verify'],


### PR DESCRIPTION
Modification to NAPSSPO-558 to add in the organization field to the global vars. 

The format for the push is now:
{url}/{org}/{app-name}-{service-name}:{version}