### PR TITLE
NAPSSPO-794 - Add check for boolean vals in runtime_step_config

### DIFF
--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -312,6 +312,35 @@ class TestStepImplementer(unittest.TestCase):
                     test_dir
                 )
     
+    def test_boolean_false_config_variable(self):
+        config = {
+            'tssc-config': {
+                'write-config-as-results': {
+                    'implementer': 'WriteConfigAsResultsStepImplementer',
+                    'config': {
+                            'required-config-key': False
+                    }
+                }
+            }
+        }
+        config_expected_step_results = {
+            'tssc-results': {
+                'write-config-as-results': {
+                    'required-config-key': False
+                }
+            }
+        }
+    
+        TSSCFactory.register_step_implementer(WriteConfigAsResultsStepImplementer)
+    
+        with TempDirectory() as test_dir:
+            self._run_step_implementer_test(
+                config,
+                'write-config-as-results',
+                config_expected_step_results,
+                test_dir
+            )
+    
     def test_one_step_existing_results_file_empty(self):
         config = {
             'tssc-config': {

--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -224,8 +224,9 @@ class StepImplementer(ABC): # pylint: disable=too-many-instance-attributes
         """
         missing_required_config_keys = []
         for required_config_key in self.required_runtime_step_config_keys():
-            if (required_config_key not in runtime_step_config) or \
-                    (not runtime_step_config[required_config_key]):
+            if ((required_config_key not in runtime_step_config) or \
+                    (not runtime_step_config[required_config_key]) and  \
+                    (not isinstance(runtime_step_config[required_config_key], bool))):
                 missing_required_config_keys.append(required_config_key)
 
         assert (not missing_required_config_keys), \

--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -225,8 +225,8 @@ class StepImplementer(ABC): # pylint: disable=too-many-instance-attributes
         missing_required_config_keys = []
         for required_config_key in self.required_runtime_step_config_keys():
             if ((required_config_key not in runtime_step_config) or \
-                    (not runtime_step_config[required_config_key]) and  \
-                    (not isinstance(runtime_step_config[required_config_key], bool))):
+                    ((not runtime_step_config[required_config_key]) and  \
+                    (not isinstance(runtime_step_config[required_config_key], bool)))):
                 missing_required_config_keys.append(required_config_key)
 
         assert (not missing_required_config_keys), \

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -177,7 +177,7 @@ class Buildah(StepImplementer):
         try:
             sh.buildah.bud(  # pylint: disable=no-member
                 '--format=' + runtime_step_config['format'],
-                '--tls-verify=' + runtime_step_config['tlsverify'],
+                '--tls-verify=' + str(runtime_step_config['tlsverify']),
                 '--layers', '-f', image_spec_file,
                 '-t', tag,
                 context,

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -140,8 +140,8 @@ class Skopeo(StepImplementer):
          '/' + application_name + '-' + service_name + ':' + (version).lower()
         try:
             sh.skopeo.copy( # pylint: disable=no-member
-                '--src-tls-verify=' + runtime_step_config['src-tls-verify'],
-                '--dest-tls-verify=' + runtime_step_config['dest-tls-verify'],
+                '--src-tls-verify=' + str(runtime_step_config['src-tls-verify']),
+                '--dest-tls-verify=' + str(runtime_step_config['dest-tls-verify']),
                 'docker-archive:' + image_tar_file,
                 destination_with_version,
                 _out=sys.stdout


### PR DESCRIPTION
Add check to allow boolean and string values in runtime_step_config
Update buildah step implementer to output boolean config values as string

https://projects.engineering.redhat.com/browse/NAPSSPO-794