### PR TITLE
NAPSSPO-955 - tssc-python-library - refactor step_implementer to not pass configuration as a dict and refactor all step implementers to get configuration from TSSC*Config objects

### DIFF
--- a/tests/helpers/sample_step_implementers.py
+++ b/tests/helpers/sample_step_implementers.py
@@ -37,7 +37,7 @@ class FooStepImplementer(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
+    def _run_step(self):
         pass
 
 class RequiredStepConfigStepImplementer(StepImplementer):
@@ -79,7 +79,7 @@ class RequiredStepConfigStepImplementer(StepImplementer):
             'required-config-key'
         ]
 
-    def _run_step(self, runtime_step_config):
+    def _run_step(self):
         pass
 
 class WriteConfigAsResultsStepImplementer(StepImplementer):
@@ -119,5 +119,7 @@ class WriteConfigAsResultsStepImplementer(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        return runtime_step_config
+    def _run_step(self):
+        return self.config.get_copy_of_runtime_step_config(
+            self.environment,
+            self.step_implementer_config_defaults())

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -2,14 +2,21 @@ import os
 import yaml
 from tssc import TSSCFactory
 
-def run_step_test_with_result_validation(temp_dir, step_name, config, expected_step_results, runtime_args=None):
+def run_step_test_with_result_validation(
+        temp_dir,
+        step_name,
+        config,
+        expected_step_results,
+        runtime_args=None,
+        environment=None):
+
     results_dir_path = os.path.join(temp_dir.path, 'tssc-results')
 
     factory = TSSCFactory(config, results_dir_path)
     if runtime_args:
         factory.config.set_step_config_overrides(step_name, runtime_args)
 
-    factory.run_step(step_name)
+    factory.run_step(step_name, environment)
 
     results_file_name = "tssc-results.yml"
     with open(os.path.join(results_dir_path, results_file_name), 'r') as step_results_file:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1030,7 +1030,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
                 }
             ])
 
-    def test_get_runtime_step_config_global_defaults_global_env_defaults_sub_step_config_sub_step_env_config_step_config_overrides(self):
+    def test_get_copy_of_runtime_step_config_global_defaults_global_env_defaults_sub_step_config_sub_step_env_config_step_config_overrides(self):
         tssc_config = TSSCConfig({
             TSSCConfig.TSSC_CONFIG_KEY: {
                 'global-defaults': {
@@ -1091,7 +1091,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
         step_config = tssc_config.get_step_config('step-foo')
         sub_step = step_config.get_sub_step('foo1')
 
-        runtime_step_config_no_given_env = sub_step.get_runtime_step_config()
+        runtime_step_config_no_given_env = sub_step.get_copy_of_runtime_step_config()
         self.assertEqual(runtime_step_config_no_given_env, {
             'global-default-unique-0': 'global-default',
             'global-default-override-by-global-env-default-0': 'global-default-override-me',
@@ -1105,7 +1105,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'global-env-default-override-by-step-config': 'step-foo-foo1'
         })
 
-        runtime_step_config_env1 = sub_step.get_runtime_step_config('env1')
+        runtime_step_config_env1 = sub_step.get_copy_of_runtime_step_config('env1')
         self.assertEqual(runtime_step_config_env1, {
             'environment-name': 'env1',
             'global-default-unique-0': 'global-default',
@@ -1123,7 +1123,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'step-foo-foo1-env-specific': 'step-foo-foo-env1'
         })
 
-        runtime_step_config_env2 = sub_step.get_runtime_step_config('env2')
+        runtime_step_config_env2 = sub_step.get_copy_of_runtime_step_config('env2')
         self.assertEqual(runtime_step_config_env2, {
             'environment-name': 'env2',
             'global-default-unique-0': 'global-default',
@@ -1141,7 +1141,8 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'step-foo-foo1-env-specific': 'step-foo-foo-env2'
         })
 
-    def test_get_runtime_step_config_default_global_defaults_global_env_defaults_sub_step_config_sub_step_env_config_step_config_overrides(self):
+
+    def test_get_copy_of_runtime_step_config_default_global_defaults_global_env_defaults_sub_step_config_sub_step_env_config_step_config_overrides(self):
         tssc_config = TSSCConfig({
             TSSCConfig.TSSC_CONFIG_KEY: {
                 'global-defaults': {
@@ -1218,7 +1219,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'default-overriden-by-step-config-overrides': 'override-me'
         }
 
-        runtime_step_config_no_given_env = sub_step.get_runtime_step_config(None, defaults)
+        runtime_step_config_no_given_env = sub_step.get_copy_of_runtime_step_config(None, defaults)
         self.assertEqual(runtime_step_config_no_given_env, {
             'global-default-unique-0': 'global-default',
             'global-default-override-by-global-env-default-0': 'global-default-override-me',
@@ -1238,7 +1239,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'default-overriden-by-step-config-overrides': 'step-foo-step-config-override'
         })
 
-        runtime_step_config_env1 = sub_step.get_runtime_step_config('env1', defaults)
+        runtime_step_config_env1 = sub_step.get_copy_of_runtime_step_config('env1', defaults)
         self.assertEqual(runtime_step_config_env1, {
             'environment-name': 'env1',
             'global-default-unique-0': 'global-default',
@@ -1262,7 +1263,7 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'default-overriden-by-step-config-overrides': 'step-foo-step-config-override'
         })
 
-        runtime_step_config_env2 = sub_step.get_runtime_step_config('env2', defaults)
+        runtime_step_config_env2 = sub_step.get_copy_of_runtime_step_config('env2', defaults)
         self.assertEqual(runtime_step_config_env2, {
             'environment-name': 'env2',
             'global-default-unique-0': 'global-default',
@@ -1285,3 +1286,105 @@ class TestTSSCSubStepConfig(BaseTSSCTestCase):
             'default-overriden-by-step-env-config': 'step-foo-foo-env2',
             'default-overriden-by-step-config-overrides': 'step-foo-step-config-override'
         })
+
+    def test_get_config_value(self):
+        tssc_config = TSSCConfig({
+            TSSCConfig.TSSC_CONFIG_KEY: {
+                'global-defaults': {
+                    'global-default-unique-0': 'global-default',
+                    'global-default-override-by-global-env-default-0': 'global-default-override-me',
+                    'global-default-override-by-step-config-0': 'global-default-override-me',
+                    'global-default-override-by-step-env-config-0': 'global-default-override-me',
+                    'global-default-override-by-step-config-override-0': 'global-default-override-me'
+                },
+                'global-environment-defaults' : {
+                    'env1': {
+                        'global-default-override-by-global-env-default-0': 'global-environment-defaults-1',
+                        'global-env-default-env1-unique-0': 'global-environment-defaults-1',
+                        'global-env-default-override-by-step-config': 'global-environment-defaults-1'
+                    },
+                    'env2': {
+                        'global-default-override-by-global-env-default-0': 'global-environment-defaults-2',
+                        'global-env-default-env2-unique-0': 'global-environment-defaults-2',
+                        'global-env-default-override-by-step-config': 'global-environment-defaults-1'
+                    }
+                },
+                'step-foo': [
+                    {
+                        'implementer': 'foo1',
+                        'config': {
+                            'step-foo-foo1-unique-0': 'step-foo-foo1',
+                            'step-foo-foo1-override-by-step-env-config': 'step-foo-foo-override-me',
+                            'step-foo-foo1-override-by-step-override': 'step-foo-foo-override-me',
+                            'global-default-override-by-step-config-0': 'step-foo-foo1',
+                            'global-env-default-override-by-step-config': 'step-foo-foo1'
+                        },
+                        'environment-config': {
+                            'env1': {
+                                'step-foo-foo1-override-by-step-env-config': 'step-foo-foo-env1',
+                                'global-default-override-by-step-env-config-0': 'step-foo-foo-env1',
+                                'step-foo-foo1-env1-unique-0': 'step-foo-foo-env1',
+                                'step-foo-foo1-env-specific': 'step-foo-foo-env1'
+                            },
+                            'env2': {
+                                'step-foo-foo1-override-by-step-env-config': 'step-foo-foo-env2',
+                                'global-default-override-by-step-env-config-0': 'step-foo-foo-env2',
+                                'step-foo-foo1-env2-unique-0': 'step-foo-foo-env2',
+                                'step-foo-foo1-env-specific': 'step-foo-foo-env2'
+                            }
+                        }
+                    }
+                ]
+
+            }
+        })
+
+        tssc_config.set_step_config_overrides('step-foo', {
+            'global-default-override-by-step-config-override-0': 'step-foo-step-config-override',
+            'step-foo-foo1-override-by-step-override' : 'step-foo-step-config-override',
+            'step-config-override-unique-0': 'step-config-override-unique'
+        })
+
+        step_config = tssc_config.get_step_config('step-foo')
+        sub_step = step_config.get_sub_step('foo1')
+
+        self.assertEqual(
+            sub_step.get_config_value('global-default-unique-0'),
+            "global-default")
+
+        self.assertEqual(
+            sub_step.get_config_value('global-default-override-by-global-env-default-0'),
+            "global-default-override-me")
+
+        self.assertEqual(
+            sub_step.get_config_value('global-default-override-by-global-env-default-0', 'env1'),
+            "global-environment-defaults-1")
+        self.assertEqual(
+            sub_step.get_config_value('global-default-override-by-global-env-default-0', 'env2'),
+            "global-environment-defaults-2")
+
+        self.assertEqual(
+            sub_step.get_config_value('global-default-override-by-step-config-0'),
+            "step-foo-foo1")
+        self.assertEqual(
+            sub_step.get_config_value('global-default-override-by-step-config-0', 'env1'),
+            "step-foo-foo1")
+
+        self.assertEqual(
+            sub_step.get_config_value('step-foo-foo1-unique-0',),
+            "step-foo-foo1")
+        self.assertEqual(
+            sub_step.get_config_value('step-foo-foo1-unique-0', 'env1'),
+            "step-foo-foo1")
+
+        self.assertEqual(
+            sub_step.get_config_value('step-foo-foo1-override-by-step-env-config',),
+            "step-foo-foo-override-me")
+        self.assertEqual(
+            sub_step.get_config_value('step-foo-foo1-override-by-step-env-config', 'env1'),
+            "step-foo-foo-env1")
+        self.assertEqual(
+            sub_step.get_config_value('step-foo-foo1-override-by-step-env-config', 'env2'),
+            "step-foo-foo-env2")
+
+        self.assertIsNone(sub_step.get_config_value('does-not-exist'))

--- a/tssc/config.py
+++ b/tssc/config.py
@@ -812,7 +812,50 @@ class TSSCSubStepConfig:
                     f" for sub step ({self.sub_step_name}) of step ({self.step_name}): {error}"
                 ) from error
 
-    def get_runtime_step_config(self, environment=None, defaults=None):
+    def get_config_value(self, key, environment=None, defaults=None):
+        """Get the configuration value for a given configuration key from the
+        merged set of configuration sources.
+
+        From least precedence to highest precedence.
+
+            1. defaults
+            2. Global Configuration Defaults (self.global_config_defaults)
+            3. Global Environment Configuration Defaults (self.global_environment_config_defaults)
+            4. Step Configuration ( self.step_config)
+            5. Step Environment Configuration (self.step_environment_config)
+            6. Step Configuration Runtime Overrides (step_config_runtime_overrides)
+
+        Also See
+        --------
+        get_copy_of_runtime_step_config
+
+        Parameters
+        ----------
+        key : str
+            Key to get the configuration value for.
+        environment : str, optional
+            Environment to include the configuration for if running in the context of
+            a specific environment.
+        defaults : dict, optional
+            If no value for the given configuration key found in any of the configuration
+            sources then use these defaults as last resort.
+
+        Returns
+        -------
+        str, int, dict, list, or bool or None
+            Value of the given configuration key or None if one does not exist
+            for this sub step in the given context with the given defaults.
+        """
+        runtime_step_config = self.__merge_runtime_step_config(environment, defaults)
+
+        if key in runtime_step_config:
+            value = copy.deepcopy(runtime_step_config[key])
+        else:
+            value = None
+
+        return value
+
+    def get_copy_of_runtime_step_config(self, environment=None, defaults=None):
         """Take all of the context about this sub step merges together a single dictionary
         with all of the configuration for a given step.
 
@@ -825,6 +868,10 @@ class TSSCSubStepConfig:
             5. Step Environment Configuration (self.step_environment_config)
             6. Step Configuration Runtime Overrides (step_config_runtime_overrides)
 
+        Also See
+        --------
+        get_config_value
+
         Parameters
         ----------
         environment : str, optional
@@ -836,15 +883,51 @@ class TSSCSubStepConfig:
         Returns
         -------
         dict
-            TODO
+            A deep copy of the merged runtime step configuration
         """
         defaults = defaults if defaults else {}
 
-        return copy.deepcopy({
+        return copy.deepcopy(self.__merge_runtime_step_config(environment, defaults))
+
+    def __merge_runtime_step_config(self, environment=None, defaults=None):
+        """Take all of the context about this sub step merges together a single dictionary
+        with all of the configuration for a given step.
+
+        From least precedence to highest precedence.
+
+            1. defaults
+            2. Global Configuration Defaults (self.global_config_defaults)
+            3. Global Environment Configuration Defaults (self.global_environment_config_defaults)
+            4. Step Configuration ( self.step_config)
+            5. Step Environment Configuration (self.step_environment_config)
+            6. Step Configuration Runtime Overrides (step_config_runtime_overrides)
+
+        Notes
+        -----
+        This is not intended to be accessed outside of this class since it gives direct access
+        to the underlying dictionaries which could in theory be changed, which would not be the
+        intended use.
+
+        Parameters
+        ----------
+        environment : str, optional
+            Environment to get the runtime step configuration for
+        defaults : dict, optional
+            Defaults to use if no other configuration specified from any other source
+            for each given key.
+
+        Returns
+        -------
+        dict
+            Merged runtime step configuration
+        """
+        defaults = defaults if defaults else {}
+
+        return {
             **defaults,
             **self.global_defaults,
             **self.get_global_environment_defaults(environment),
             **self.sub_step_config,
             **self.get_sub_step_env_config(environment),
             **self.step_config_overrides,
-        })
+        }

--- a/tssc/step_implementers/canary_test/selenium.py
+++ b/tssc/step_implementers/canary_test/selenium.py
@@ -92,15 +92,8 @@ class Selenium(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/container_image_static_compliance_scan/openscap.py
+++ b/tssc/step_implementers/container_image_static_compliance_scan/openscap.py
@@ -92,15 +92,8 @@ class OpenSCAP(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/container_image_static_vulnerability_scan/openscap.py
+++ b/tssc/step_implementers/container_image_static_vulnerability_scan/openscap.py
@@ -92,15 +92,8 @@ class OpenSCAP(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -133,26 +133,19 @@ class Buildah(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        context = runtime_step_config['context']
-        image_spec_file = runtime_step_config['imagespecfile']
+        context = self.get_config_value('context')
+        image_spec_file = self.get_config_value('imagespecfile')
         image_spec_file_location = context + '/' + image_spec_file
-        application_name = runtime_step_config['application-name']
-        service_name = runtime_step_config['service-name']
+        application_name = self.get_config_value('application-name')
+        service_name = self.get_config_value('service-name')
 
         if not os.path.exists(image_spec_file_location):
             raise ValueError('Image specification file does not exist in location: '
@@ -176,8 +169,8 @@ class Buildah(StepImplementer):
 
         try:
             sh.buildah.bud(  # pylint: disable=no-member
-                '--format=' + runtime_step_config['format'],
-                '--tls-verify=' + str(runtime_step_config['tlsverify']),
+                '--format=' + self.get_config_value('format'),
+                '--tls-verify=' + str(self.get_config_value('tlsverify')),
                 '--layers', '-f', image_spec_file,
                 '-t', tag,
                 context,

--- a/tssc/step_implementers/generate_metadata/git.py
+++ b/tssc/step_implementers/generate_metadata/git.py
@@ -101,23 +101,16 @@ class Git(StepImplementer): # pylint: disable=too-few-public-methods
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        repo_root = runtime_step_config['repo-root']
-        build_string_length = runtime_step_config['build-string-length']
+        repo_root = self.get_config_value('repo-root')
+        build_string_length = self.get_config_value('build-string-length')
 
         try:
             repo = Repo(repo_root)

--- a/tssc/step_implementers/generate_metadata/maven.py
+++ b/tssc/step_implementers/generate_metadata/maven.py
@@ -94,22 +94,15 @@ class Maven(StepImplementer): # pylint: disable=too-few-public-methods
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        pom_file = runtime_step_config['pom-file']
+        pom_file = self.get_config_value('pom-file')
 
         # verify runtime config
         if not os.path.exists(pom_file):

--- a/tssc/step_implementers/generate_metadata/npm.py
+++ b/tssc/step_implementers/generate_metadata/npm.py
@@ -94,22 +94,15 @@ class Npm(StepImplementer): # pylint: disable=too-few-public-methods
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        package_file = runtime_step_config['package-file']
+        package_file = self.get_config_value('package-file')
 
         # verify runtime config
         if not os.path.exists(package_file):

--- a/tssc/step_implementers/generate_metadata/semantic_version.py
+++ b/tssc/step_implementers/generate_metadata/semantic_version.py
@@ -175,15 +175,8 @@ class SemanticVersion(StepImplementer): # pylint: disable=too-few-public-methods
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
@@ -193,34 +186,32 @@ class SemanticVersion(StepImplementer): # pylint: disable=too-few-public-methods
         app_version = None
         pre_release = None
         build = None
-        release_branch = runtime_step_config['release-branch']
+        release_branch = self.get_config_value('release-branch')
 
         current_step_results = self.current_step_results()
-        if 'app-version' in runtime_step_config:
-            app_version = runtime_step_config['app-version']
-        elif 'app-version' in current_step_results:
+
+        app_version = self.get_config_value('app-version')
+        if app_version is None and 'app-version' in current_step_results:
             app_version = current_step_results['app-version']
-        else:
+        if app_version is None:
             raise ValueError(
                 """No value for (app-version) provided via runtime flag
                 (app-version) or from prior step implementer ({0}).
                 """.format(self.step_name))
 
-        if 'pre-release' in runtime_step_config:
-            pre_release = runtime_step_config['pre-release']
-        elif 'pre-release' in current_step_results:
+        pre_release = self.get_config_value('pre-release')
+        if pre_release is None and 'pre-release' in current_step_results:
             pre_release = current_step_results['pre-release']
-        else:
+        if pre_release is None:
             raise ValueError(
                 """No value for (pre_release) provided via runtime flag
                 (pre-release) or from prior step implementer ({0})
                 """.format(self.step_name))
 
-        if 'build' in runtime_step_config:
-            build = runtime_step_config['build']
-        elif 'build' in current_step_results:
+        build = self.get_config_value('build')
+        if build is None and 'build' in current_step_results:
             build = current_step_results['build']
-        else:
+        if build is None:
             raise ValueError(
                 """No value for (build) provided via runtime flag
                 (build) or from prior step implementer ({0})

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -191,24 +191,17 @@ class Maven(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        pom_file = runtime_step_config['pom-file']
-        artifact_extensions = runtime_step_config['artifact-extensions']
-        artifact_parent_dir = runtime_step_config['artifact-parent-dir']
+        pom_file = self.get_config_value('pom-file')
+        artifact_extensions = self.get_config_value('artifact-extensions')
+        artifact_parent_dir = self.get_config_value('artifact-parent-dir')
 
         if not os.path.exists(pom_file):
             raise ValueError('Given pom file does not exist: ' + pom_file)

--- a/tssc/step_implementers/package/npm.py
+++ b/tssc/step_implementers/package/npm.py
@@ -92,15 +92,8 @@ class NPM(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/push_artifacts/maven.py
+++ b/tssc/step_implementers/push_artifacts/maven.py
@@ -173,15 +173,8 @@ class Maven(StepImplementer):
             not any(element in runtime_step_config for element in AUTHENTICATION_CONFIG) \
         ), 'Either username or password is not set. Neither or both must be set.'
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
@@ -191,13 +184,12 @@ class Maven(StepImplementer):
         user = ''
         password = ''
 
-        url = runtime_step_config['url']
+        url = self.get_config_value('url')
 
-        if any(element in runtime_step_config for element in AUTHENTICATION_CONFIG):
-            if(runtime_step_config.get('user') \
-              and runtime_step_config.get('password')):
-                user = runtime_step_config.get('user')
-                password = runtime_step_config.get('password')
+        if self.has_config_value(AUTHENTICATION_CONFIG):
+            if(self.get_config_value('user') and self.get_config_value('password')):
+                user = self.get_config_value('user')
+                password = self.get_config_value('password')
 
         # ----- get generate-metadata items
         # Required: Get the generate-metadata.version

--- a/tssc/step_implementers/push_artifacts/npm.py
+++ b/tssc/step_implementers/push_artifacts/npm.py
@@ -94,15 +94,8 @@ class NPM(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/push_container_image/skopeo.py
+++ b/tssc/step_implementers/push_container_image/skopeo.py
@@ -104,15 +104,8 @@ class Skopeo(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
@@ -126,9 +119,9 @@ class Skopeo(StepImplementer):
         else:
             print('No version found in metadata. Using latest')
 
-        application_name = runtime_step_config['application-name']
-        service_name = runtime_step_config['service-name']
-        organization = runtime_step_config['organization']
+        application_name = self.get_config_value('application-name')
+        service_name = self.get_config_value('service-name')
+        organization = self.get_config_value('organization')
 
         image_tar_file = ''
         if(self.get_step_results(DefaultSteps.CREATE_CONTAINER_IMAGE) and \
@@ -138,12 +131,12 @@ class Skopeo(StepImplementer):
         else:
             raise RuntimeError('Missing image tar file from ' + DefaultSteps.CREATE_CONTAINER_IMAGE)
 
-        destination_with_version = runtime_step_config['destination-url'] + '/' + organization + \
+        destination_with_version = self.get_config_value('destination-url') + '/' + organization + \
          '/' + application_name + '-' + service_name + ':' + (version).lower()
         try:
             sh.skopeo.copy( # pylint: disable=no-member
-                '--src-tls-verify=' + str(runtime_step_config['src-tls-verify']),
-                '--dest-tls-verify=' + str(runtime_step_config['dest-tls-verify']),
+                '--src-tls-verify=' + str(self.get_config_value('src-tls-verify')),
+                '--dest-tls-verify=' + str(self.get_config_value('dest-tls-verify')),
                 'docker-archive:' + image_tar_file,
                 'docker://' + destination_with_version,
                 _out=sys.stdout
@@ -154,7 +147,7 @@ class Skopeo(StepImplementer):
         results = {
             'image-tag' : destination_with_version,
             'image-version' : (version).lower(),
-            'image-url' : runtime_step_config['destination-url']
+            'image-url' : self.get_config_value('destination-url')
         }
 
         return results

--- a/tssc/step_implementers/tag_source/git.py
+++ b/tssc/step_implementers/tag_source/git.py
@@ -141,15 +141,8 @@ class Git(StepImplementer):
             not any(element in runtime_step_config for element in AUTHENTICATION_CONFIG) \
         ), 'Either username or password is not set. Neither or both must be set.'
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
@@ -159,11 +152,11 @@ class Git(StepImplementer):
         username = None
         password = None
 
-        if any(element in runtime_step_config for element in AUTHENTICATION_CONFIG):
-            if(runtime_step_config.get('username') \
-              and runtime_step_config.get('password')):
-                username = runtime_step_config.get('username')
-                password = runtime_step_config.get('password')
+        if self.has_config_value(AUTHENTICATION_CONFIG):
+            if(self.get_config_value('username') \
+              and self.get_config_value('password')):
+                username = self.get_config_value('username')
+                password = self.get_config_value('password')
             else:
                 raise ValueError(
                     'Both username and password must have ' \
@@ -173,7 +166,7 @@ class Git(StepImplementer):
             print('No username/password found, assuming ssh')
         tag = self._get_tag()
         self._git_tag(tag)
-        git_url = self._git_url(runtime_step_config)
+        git_url = self._git_url()
         if git_url.startswith('http://'):
             if username and password:
                 self._git_push('http://' + username + ':' + password + '@' + git_url[7:])
@@ -206,11 +199,10 @@ class Git(StepImplementer):
             print('No version found in metadata. Using latest')
         return tag
 
-    @staticmethod
-    def _git_url(runtime_step_config):
+    def _git_url(self):
         return_val = None
-        if runtime_step_config.get('url'):
-            return_val = runtime_step_config.get('url')
+        if self.get_config_value('url'):
+            return_val = self.get_config_value('url')
         else:
             try:
                 return_val = sh.git.config(

--- a/tssc/step_implementers/uat/cucumber.py
+++ b/tssc/step_implementers/uat/cucumber.py
@@ -92,15 +92,8 @@ class Cucumber(StepImplementer):
         """
         return []
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------

--- a/tssc/step_implementers/unit_test/maven.py
+++ b/tssc/step_implementers/unit_test/maven.py
@@ -130,23 +130,16 @@ class Maven(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _run_step(self, runtime_step_config):
-        """
-        Runs the TSSC step implemented by this StepImplementer.
-
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _run_step(self):
+        """Runs the TSSC step implemented by this StepImplementer.
 
         Returns
         -------
         dict
             Results of running this step.
         """
-        pom_file = runtime_step_config['pom-file']
-        fail_on_no_tests = runtime_step_config['fail-on-no-tests']
+        pom_file = self.get_config_value('pom-file')
+        fail_on_no_tests = self.get_config_value('fail-on-no-tests')
 
         if not os.path.exists(pom_file):
             raise ValueError('Given pom file does not exist: ' + pom_file)


### PR DESCRIPTION
# NOTE

This contains https://github.com/rhtconsulting/tssc-python-package/pull/69 which should be reviewed and merged first.