### PR TITLE
Feature/napsspo 996 : use a settings.xml for all maven steps to allow for disconnected.

### DIFF
--- a/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
@@ -1,24 +1,20 @@
-import os
-
-import unittest
 from testfixtures import TempDirectory
 
-from tssc import TSSCFactory
-from tssc.step_implementers.generate_metadata import Maven
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
 
-from tests.helpers.test_utils import *
+import tests.helpers.test_utils
+
 
 class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
     def test_pom_file_valid_runtime_config_pom_file(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml',b'''<project>
+            temp_dir.write('pom.xml', b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
             config = {
                 'tssc-config': {
                     'generate-metadata': {
@@ -27,17 +23,19 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
-            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'pom-file': str(pom_file_path)})
+            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
+                                                                          expected_step_results,
+                                                                          runtime_args={'pom-file': str(pom_file_path)})
 
     def test_pom_file_valid_old(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml',b'''<project>
+            temp_dir.write('pom.xml', b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
             config = {
                 'tssc-config': {
                     'generate-metadata': {
@@ -50,11 +48,12 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
 
-            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results)
+            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
+                                                                          expected_step_results)
 
     def test_pom_file_valid_with_namespace(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml',b'''<?xml version="1.0"?>
+            temp_dir.write('pom.xml', b'''<?xml version="1.0"?>
     <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
       xmlns="http://maven.apache.org/POM/4.0.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -63,7 +62,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
 
             config = {
                 'tssc-config': {
@@ -77,16 +76,17 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
 
-            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results)
+            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
+                                                                          expected_step_results)
 
     def test_pom_file_missing_version(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml',b'''<project>
+            temp_dir.write('pom.xml', b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
     </project>''')
-            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
 
             config = {
                 'tssc-config': {
@@ -98,7 +98,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = TSSCFactory(config)
+            factory = tests.helpers.test_utils.TSSCFactory(config)
 
         with self.assertRaisesRegex(
                 ValueError,
@@ -113,11 +113,10 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tests.helpers.test_utils.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist-pom.xml"):
-
             factory.config.set_step_config_overrides(
                 'generate-metadata',
                 {'pom-file': 'does-not-exist-pom.xml'})
@@ -131,11 +130,10 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tests.helpers.test_utils.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist-pom.xml"):
-
             factory.config.set_step_config_overrides(
                 'generate-metadata',
                 {'pom-file': 'does-not-exist-pom.xml'})
@@ -152,7 +150,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tests.helpers.test_utils.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist.pom"):
@@ -169,7 +167,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tests.helpers.test_utils.TSSCFactory(config)
         with self.assertRaisesRegex(
                 AssertionError,
                 r"The runtime step configuration \(\{'pom-file': None\}\) is missing the required configuration keys \(\['pom-file'\]\)"):

--- a/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
@@ -1,20 +1,24 @@
+import os
+
+import unittest
 from testfixtures import TempDirectory
 
+from tssc import TSSCFactory
+from tssc.step_implementers.generate_metadata import Maven
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
 
-import tests.helpers.test_utils
-
+from tests.helpers.test_utils import *
 
 class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
     def test_pom_file_valid_runtime_config_pom_file(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml', b'''<project>
+            temp_dir.write('pom.xml',b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             config = {
                 'tssc-config': {
                     'generate-metadata': {
@@ -23,19 +27,17 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
-            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
-                                                                          expected_step_results,
-                                                                          runtime_args={'pom-file': str(pom_file_path)})
+            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'pom-file': str(pom_file_path)})
 
     def test_pom_file_valid_old(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml', b'''<project>
+            temp_dir.write('pom.xml',b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             config = {
                 'tssc-config': {
                     'generate-metadata': {
@@ -48,12 +50,11 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
 
-            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
-                                                                          expected_step_results)
+            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results)
 
     def test_pom_file_valid_with_namespace(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml', b'''<?xml version="1.0"?>
+            temp_dir.write('pom.xml',b'''<?xml version="1.0"?>
     <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
       xmlns="http://maven.apache.org/POM/4.0.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -62,7 +63,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
         <artifactId>my-app</artifactId>
         <version>42.1</version>
     </project>''')
-            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
 
             config = {
                 'tssc-config': {
@@ -76,17 +77,16 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
             }
             expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': '42.1'}}}
 
-            tests.helpers.test_utils.run_step_test_with_result_validation(temp_dir, 'generate-metadata', config,
-                                                                          expected_step_results)
+            run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results)
 
     def test_pom_file_missing_version(self):
         with TempDirectory() as temp_dir:
-            temp_dir.write('pom.xml', b'''<project>
+            temp_dir.write('pom.xml',b'''<project>
         <modelVersion>4.0.0</modelVersion>
         <groupId>com.mycompany.app</groupId>
         <artifactId>my-app</artifactId>
     </project>''')
-            pom_file_path = tests.helpers.test_utils.os.path.join(temp_dir.path, 'pom.xml')
+            pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
 
             config = {
                 'tssc-config': {
@@ -98,7 +98,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = tests.helpers.test_utils.TSSCFactory(config)
+            factory = TSSCFactory(config)
 
         with self.assertRaisesRegex(
                 ValueError,
@@ -113,10 +113,11 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tests.helpers.test_utils.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist-pom.xml"):
+
             factory.config.set_step_config_overrides(
                 'generate-metadata',
                 {'pom-file': 'does-not-exist-pom.xml'})
@@ -130,10 +131,11 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tests.helpers.test_utils.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist-pom.xml"):
+
             factory.config.set_step_config_overrides(
                 'generate-metadata',
                 {'pom-file': 'does-not-exist-pom.xml'})
@@ -150,7 +152,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tests.helpers.test_utils.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 r"Given pom file does not exist: does-not-exist.pom"):
@@ -167,7 +169,7 @@ class TestStepImplementerGenerateMetadataMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tests.helpers.test_utils.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 AssertionError,
                 r"The runtime step configuration \(\{'pom-file': None\}\) is missing the required configuration keys \(\['pom-file'\]\)"):

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -1,14 +1,12 @@
 import os
 import sys
-import sh
 from pathlib import Path
-
-import unittest
 from unittest.mock import patch
+import sh
+
 from testfixtures import TempDirectory
 
-from tssc import TSSCFactory
-from tssc.step_implementers.package import Maven
+import tssc
 
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
 from tests.helpers.test_utils import run_step_test_with_result_validation
@@ -65,7 +63,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = TSSCFactory(config)
+            factory = tssc.TSSCFactory(config)
             with self.assertRaisesRegex(
                     ValueError,
                     'Given pom file does not exist: .*'):
@@ -130,13 +128,18 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
 
-            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artifact_file_name])
+            mvn_mock.side_effect = create_mvn_side_effect(pom_file_path,
+                                                          'target',
+                                                          [artifact_file_name])
             run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            settings_file_path = temp_dir.path + "/tssc-working/package/settings.xml"
             mvn_mock.assert_called_once_with(
                 'clean',
                 'install',
                 '-f',
                 pom_file_path,
+                '-s',
+                settings_file_path,
                 _out=sys.stdout,
                 _err=sys.stderr
             )
@@ -202,8 +205,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     'pom resulted in 0 with expected artifact extensions (.*), this is unsupported'):
-
-                    run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+                run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
 
     @patch('sh.mvn', create=True)
     def test_mvn_multiple_jars(self, mvn_mock):
@@ -292,7 +294,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = TSSCFactory(config)
+            factory = tssc.TSSCFactory(config)
             artifact_file_name = '{artifact_id}-{version}.{package}'.format(
                 artifact_id=artifact_id,
                 version=version,
@@ -361,11 +363,14 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
 
             mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artifact_file_name])
             run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            settings_file_path = temp_dir.path + "/tssc-working/package/settings.xml"
             mvn_mock.assert_called_once_with(
                 'clean',
                 'install',
                 '-f',
                 pom_file_path,
+                '-s',
+                settings_file_path,
                 _out=sys.stdout,
                 _err=sys.stderr
             )
@@ -420,11 +425,14 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
             }
             mvn_mock.side_effect = create_mvn_side_effect(pom_file_path, 'target', [artifact_file_name])
             run_step_test_with_result_validation(temp_dir, 'package', config, expected_step_results)
+            settings_file_path = temp_dir.path + "/tssc-working/package/settings.xml"
             mvn_mock.assert_called_once_with(
                 'clean',
                 'install',
                 '-f',
                 pom_file_path,
+                '-s',
+                settings_file_path,
                 _out=sys.stdout,
                 _err=sys.stderr
             )
@@ -455,7 +463,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = TSSCFactory(config)
+            factory = tssc.TSSCFactory(config)
             with self.assertRaisesRegex(
                     RuntimeError,
                     'Error invoking mvn:.*'):
@@ -470,7 +478,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tssc.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 "Given pom file does not exist: pom.xml"):
@@ -485,7 +493,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tssc.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 "Given pom file does not exist: does-not-exist-pom.xml"):
@@ -507,7 +515,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tssc.TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 'Given pom file does not exist: does-not-exist.pom'):
@@ -525,7 +533,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = TSSCFactory(config)
+        factory = tssc.TSSCFactory(config)
         with self.assertRaisesRegex(
                 AssertionError,
                 r"The runtime step configuration \(\{'pom-file': None, 'artifact-extensions': \['jar', 'war', 'ear'\], 'artifact-parent-dir': 'target'\}\) is missing the required configuration keys \(\['pom-file'\]\)"):

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -7,7 +7,7 @@ import sh
 
 from testfixtures import TempDirectory
 
-import tssc
+from tssc import TSSCFactory
 
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
 from tests.helpers.test_utils import run_step_test_with_result_validation, Any
@@ -64,7 +64,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = tssc.TSSCFactory(config)
+            factory = TSSCFactory(config)
             with self.assertRaisesRegex(
                     ValueError,
                     'Given pom file does not exist: .*'):
@@ -295,7 +295,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = tssc.TSSCFactory(config)
+            factory = TSSCFactory(config)
             artifact_file_name = '{artifact_id}-{version}.{package}'.format(
                 artifact_id=artifact_id,
                 version=version,
@@ -464,7 +464,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = tssc.TSSCFactory(config)
+            factory = TSSCFactory(config)
             with self.assertRaisesRegex(
                     RuntimeError,
                     'Error invoking mvn:.*'):
@@ -479,7 +479,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tssc.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 "Given pom file does not exist: pom.xml"):
@@ -494,7 +494,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tssc.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 "Given pom file does not exist: does-not-exist-pom.xml"):
@@ -516,7 +516,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tssc.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 ValueError,
                 'Given pom file does not exist: does-not-exist.pom'):
@@ -534,7 +534,7 @@ class TestStepImplementerPackageMaven(BaseTSSCTestCase):
                 }
             }
         }
-        factory = tssc.TSSCFactory(config)
+        factory = TSSCFactory(config)
         with self.assertRaisesRegex(
                 AssertionError,
                 r"The runtime step configuration \(\{'pom-file': None, 'artifact-extensions': \['jar', 'war', 'ear'\], 'artifact-parent-dir': 'target'\}\) is missing the required configuration keys \(\['pom-file'\]\)"):

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -3,7 +3,6 @@ import sh
 from io import IOBase
 from pathlib import Path
 from unittest.mock import patch
-import sh
 
 from testfixtures import TempDirectory
 

--- a/tests/step_implementers/uat/uat_maven_test.py
+++ b/tests/step_implementers/uat/uat_maven_test.py
@@ -2,6 +2,7 @@
 
 Tests the Maven Cucumber UAT step.
 """
+import sys
 from os import path, rmdir, makedirs
 from sys import stdout, stderr
 from unittest.mock import patch
@@ -332,6 +333,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                 }
             }
 
+            settings_file_path = f'{temp_dir.path}/tssc-working/uat/settings.xml'
             run_step_test_with_result_validation(temp_dir, 'uat', config, expected_step_results)
             mvn_mock.assert_called_once_with(
                 'clean',
@@ -342,6 +344,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     'json:target/cucumber/cucumber.json',
                 'test',
                 '-f', pom_file_path,
+                '-s', settings_file_path,
                 _out=stdout,
                 _err=stderr
             )
@@ -413,6 +416,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                 }
             }
 
+            settings_file_path = f'{temp_dir.path}/tssc-working/uat/settings.xml'
             run_step_test_with_result_validation(temp_dir, 'uat', config, expected_step_results)
             mvn_mock.assert_called_once_with(
                 'clean',
@@ -423,8 +427,9 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     'json:target/cucumber/cucumber.json',
                 'test',
                 '-f', pom_file_path,
+                '-s', settings_file_path,
                 _out=stdout,
-                _err=stderr
+                _err=sys.stderr
             )
 
     def test_uat_test_missing_surefire_plugin_in_pom(self):
@@ -444,7 +449,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     }
                 }
             }
-            factory = TSSCFactory(config)
+            factory = TSSCFactory(config, temp_dir)
             with self.assertRaisesRegex(
                     ValueError,
                     'Uat dependency "maven-surefire-plugin" missing from POM.'):
@@ -603,6 +608,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                 }
             }
 
+            settings_file_path = f'{temp_dir.path}/tssc-working/uat/settings.xml'
             run_step_test_with_result_validation(temp_dir, 'uat', config, expected_step_results)
             mvn_mock.assert_called_once_with(
                 'clean',
@@ -613,6 +619,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     'json:target/cucumber/cucumber.json',
                 'test',
                 '-f', pom_file_path,
+                '-s', settings_file_path,
                 _out=stdout,
                 _err=stderr
             )
@@ -735,6 +742,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                 }
             }
 
+            settings_file_path = f'{temp_dir.path}/tssc-working/uat/settings.xml'
             run_step_test_with_result_validation(temp_dir, 'uat', config, expected_step_results)
             mvn_mock.assert_called_once_with(
                 'clean',
@@ -745,6 +753,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     'json:target/custom-cucumber/cucumber.json',
                 'test',
                 '-f', pom_file_path,
+                '-s', settings_file_path,
                 _out=stdout,
                 _err=stderr
             )
@@ -828,6 +837,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                 }
             }
 
+            settings_file_path = f'{temp_dir.path}/tssc-working/uat/settings.xml'
             run_step_test_with_result_validation(temp_dir, 'uat', config, expected_step_results)
             mvn_mock.assert_called_once_with(
                 'clean',
@@ -838,6 +848,7 @@ class TestStepImplementerUatTest(BaseTSSCTestCase):
                     'json:target/cucumber/cucumber.json',
                 'test',
                 '-f', pom_file_path,
+                '-s', settings_file_path,
                 _out=stdout,
                 _err=stderr
             )

--- a/tests/step_implementers/uat/uat_maven_test.py
+++ b/tests/step_implementers/uat/uat_maven_test.py
@@ -2,7 +2,6 @@
 
 Tests the Maven Cucumber UAT step.
 """
-import sys
 from os import path, rmdir, makedirs
 from io import IOBase
 from unittest.mock import patch

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -114,7 +114,7 @@ class TestStepImplementerUnitTest(BaseTSSCTestCase):
                 'Given pom file does not exist: does-not-exist.pom'):
             factory.run_step('unit-test')
 
-    @patch('sh.mvn', create=True, side_effect=sh.ErrorReturnCode('mvn clean test', b'mock out', b'mock error'))
+    @patch('sh.mvn', create=True, side_effect = sh.ErrorReturnCode('mvn clean test', b'mock out', b'mock error'))
     def test_mvn_error_return_code(self, mvn_mock):
         group_id = 'com.mycompany.app'
         artifact_id = 'my-app'

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -14,7 +14,6 @@ from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
 
 from test_utils import *
 
-
 def create_mvn_side_effect(pom_file, artifact_parent_dir, artifact_names, throw_mvn_exception=False):
     """simulates what mvn does by touching files.
 
@@ -61,7 +60,6 @@ def create_mvn_side_effect(pom_file, artifact_parent_dir, artifact_names, throw_
                 Path(artifact_path).touch()
 
     return mvn_side_effect
-
 
 class TestStepImplementerUnitTest(BaseTSSCTestCase):
 

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -1,0 +1,119 @@
+"""Test for maven.py
+
+Test for the utility for maven operations.
+"""
+from testfixtures import TempDirectory
+from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
+from tssc.utils.maven import generate_maven_settings
+
+
+class TestMavenUtils(BaseTSSCTestCase):
+    # def test_generate_maven_settings_maven_servers_is_none(self):
+
+    def test_generate_maven_servers_exist(self):
+        maven_servers = [
+            {
+                "id": "one",
+                "username": "user1",
+                "password": "password1"
+            }
+        ]
+
+        settings = '''<settings><servers><server><id>one</id><username>user1</username><password>password1</password></server></servers></settings>'''
+
+        with TempDirectory() as temp_dir:
+            generate_maven_settings(temp_dir.path, maven_servers, None, None)
+            with open(temp_dir.path + '/settings.xml', 'r') as tester:
+                results = tester.read()
+                assert results == settings
+
+    def test_generate_maven_servers_id_does_not_exist(self):
+        maven_servers = [
+            {
+                "username": "user1",
+                "password": "password1"
+            }
+        ]
+        with TempDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, 'id is required for maven_servers.'):
+                generate_maven_settings(temp_dir.path, maven_servers, None, None)
+
+    def test_generate_maven_servers_username_does_not_exist(self):
+        maven_servers = [
+            {
+                "id": "one",
+                "password": "password1"
+            }
+        ]
+        with TempDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError,
+                                        'username and password are required for maven_servers.'):
+                generate_maven_settings(temp_dir.path, maven_servers, None, None)
+
+    def test_generate_maven_repositories_exists(self):
+        maven_repositories = [
+            {
+                "id": "repo1",
+                "url": "repo_url1",
+                "releases": "true",
+                "snapshots": "true"
+            }
+        ]
+        settings = '''<settings><profiles><profile><repositories><repository><id>repo1</id><url>repo_url1</url><releases><enabled>true</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository></repositories></profile></profiles></settings>'''
+
+        with TempDirectory() as temp_dir:
+            generate_maven_settings(temp_dir.path, None, maven_repositories, None)
+            with open(temp_dir.path + '/settings.xml', 'r') as tester:
+                results = tester.read()
+                assert results == settings
+
+    def test_generate_maven_repositories_id_does_not_exists(self):
+        maven_repositories = [
+            {
+                "url": "repo_url1",
+                "releases": "true",
+                "snapshots": "true"
+            }
+        ]
+        with TempDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError,
+                                        'id and url are required for maven_repositories.'):
+                generate_maven_settings(temp_dir.path, None, maven_repositories, None)
+
+    def test_generate_maven_mirrors_exists(self):
+        maven_mirrors = [
+            {
+                "id": "mirror1",
+                "url": "mirror_url1",
+                "mirror-of": "false"
+            }
+        ]
+
+        settings = '''<settings><mirrors><mirror><id>mirror1</id><url>mirror_url1</url><mirrorOf>false</mirrorOf></mirror></mirrors></settings>'''
+
+        with TempDirectory() as temp_dir:
+            generate_maven_settings(temp_dir.path, None, None, maven_mirrors)
+            with open(temp_dir.path + '/settings.xml', 'r') as tester:
+                results = tester.read()
+                assert results == settings
+
+    def test_generate_maven_mirrors_exists_id_does_not_exists(self):
+        maven_mirrors = [
+            {
+                "url": "mirror_url1",
+                "mirror-of": "false"
+            }
+        ]
+        with TempDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError,
+                                        'id, url and mirrorOf are required for maven_mirrors.'):
+                generate_maven_settings(temp_dir.path, None, None, maven_mirrors)
+
+    def test_generate_maven_mirrors_empty(self):
+        settings = '<settings />'
+
+        with TempDirectory() as temp_dir:
+            generate_maven_settings(temp_dir.path, None, None, None)
+            with open(temp_dir.path + '/settings.xml', 'r') as tester:
+                results = tester.read()
+                assert results == settings

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -109,6 +109,15 @@ class TestMavenUtils(BaseTSSCTestCase):
                                         'id, url and mirrorOf are required for maven_mirrors.'):
                 generate_maven_settings(temp_dir.path, None, None, maven_mirrors)
 
+    def test_generate_maven_params_empty(self):
+        settings = '<settings />'
+
+        with TempDirectory() as temp_dir:
+            generate_maven_settings(temp_dir.path, None, None, None)
+            with open(temp_dir.path + '/settings.xml', 'r') as tester:
+                results = tester.read()
+                assert results == settings
+
     def test_generate_maven_mirrors_empty(self):
         settings = '<settings />'
 

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -28,6 +28,7 @@ class TestMavenUtils(BaseTSSCTestCase):
                 assert results == settings
 
     def test_generate_maven_servers_id_does_not_exist(self):
+        
         maven_servers = [
             {
                 "username": "user1",
@@ -48,7 +49,7 @@ class TestMavenUtils(BaseTSSCTestCase):
         with TempDirectory() as temp_dir:
             with self.assertRaisesRegex(ValueError,
                                         'username and password are required for maven_servers.'):
-                generate_maven_settings(temp_dir.path, maven_servers, None, None)
+                generate_maven_settings(temp_dir.path, maven_servers, maven_mirrors, None)
 
     def test_generate_maven_repositories_exists(self):
         maven_repositories = [

--- a/tssc/__init__.py
+++ b/tssc/__init__.py
@@ -173,7 +173,7 @@ From least precedence to highest precedence.
         - id: ''
           url: ''
           mirror-of: ''
-          
+
         # Dictionary of container registries to authenticate with.
         # Suggest putting in global configuration so it can be used for creating and pushing
         # images. But can also or instead be put in the individual steps if say different

--- a/tssc/step_implementers/package/maven.py
+++ b/tssc/step_implementers/package/maven.py
@@ -180,7 +180,7 @@ class Maven(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _settings_file(self):
+    def _generate_maven_settings(self):
         # ----- build settings.xml
         maven_servers = ConfigValue.convert_leaves_to_values(
             self.get_config_value('maven-servers')
@@ -211,7 +211,7 @@ class Maven(StepImplementer):
         if not os.path.exists(pom_file):
             raise ValueError('Given pom file does not exist: ' + pom_file)
 
-        settings_file = self._settings_file()
+        settings_file = self._generate_maven_settings()
 
         try:
             sh.mvn(  # pylint: disable=no-member,

--- a/tssc/step_implementers/push_artifacts/maven.py
+++ b/tssc/step_implementers/push_artifacts/maven.py
@@ -74,6 +74,7 @@ Example: Generated Maven Deploy (uses both step configuration and previous resul
       -Dfile=package.artifact.path
       -Dpackaging=package.artifact.package-type
       -DrepositoryId=maven-push-artifact-repo-id
+      -s settings.xml
 
 Example: Results
 

--- a/tssc/step_implementers/push_artifacts/maven.py
+++ b/tssc/step_implementers/push_artifacts/maven.py
@@ -160,7 +160,7 @@ class Maven(StepImplementer):
             return self.get_step_results('package')['artifacts']
         raise ValueError('package results missing artifacts')
 
-    def _settings_file(self):
+    def _generate_maven_settings(self):
         # ----- build settings.xml
         maven_servers = ConfigValue.convert_leaves_to_values(
             self.get_config_value('maven-servers')
@@ -193,7 +193,7 @@ class Maven(StepImplementer):
 
         maven_push_artifact_repo_id = self.get_config_value('maven-push-artifact-repo-id')
         maven_push_artifact_repo_url = self.get_config_value('maven-push-artifact-repo-url')
-        settings_file = self._settings_file()
+        settings_file = self._generate_maven_settings()
 
         report_artifacts = []
 

--- a/tssc/step_implementers/push_artifacts/maven.py
+++ b/tssc/step_implementers/push_artifacts/maven.py
@@ -7,11 +7,10 @@ Step configuration key(s) for this step:
 
 | Key                 | Required | Default | Description
 |---------------------|----------|---------|------------
-| `url`               | True     | N/A     | URL to the artifact repository
-| `user`              | False    | N/A     | Repository user for authenication
-| `password`          | False    | N/A     | Resository password for authentication
-
-`user` and `password` can be specifed as runtime arguments.
+| `maven-push_        | True     | N/A     | id for the maven servers and mirrors
+| `artifact-repo-id`  |          |         |
+| `maven-push_        | True     | N/A     | url for the maven servers and mirrors
+| `artifact-repo-url` |          |         |
 
 Expected Previous Step Results
 ------------------------------
@@ -20,10 +19,10 @@ Results expected from previous steps:
 
 | Step Name           |  Key               | Description
 |---------------------|--------------------|------------
-| `generate-metadata` | `version`          | The version to be used to deploy to artifactory.
+| `generate-metadata` | `version`          | The version to be used to deploy to the repository.
 | `package`           | `artifacts`        | Artifacts is an array of `artifact`.
 |                     |                    | Each element of an `artifact` will be used
-|                     |                    | as a parameter to deploy to artifactory:
+|                     |                    | as a parameter to deploy to repository:
 |                     |                    | * artifact.group-id
 |                     |                    | * artifact.artifact-id
 |                     |                    | * artifact.path
@@ -34,19 +33,24 @@ Results
 
 Results output by this step:
 
-| Key             | Description
-|-----------------|------------
-| `artifacts`     | An array of dictionaries describing the push results
+| Key                | Description
+|--------------------|------------
+| `result`           | Dictionary of results
+| `report-artifacts` | An array of dictionaries describing the push results
 
-Elements in the `artifacts` dictionary:
+Elements in the `result` dictionary:
+| `success`          | True or False
+| `message`          | Overall status
 
-| Elements        | Description
-|-----------------|------------
-| `url`           | URL to the artifact pushed to the artifact repository
-| `path`          | Absolute path to the artifact pushed to the artifact repository
-| `artifact-id`   | Maven artifact ID pushed to the artifact repository
-| `group-id`      | Maven group ID pushed to the artifact repository
-| `version`       | Version pushed to the artifact repository
+Elements in the `report-artifacts` dictionary:
+
+| Elements           | Description
+|--------------------|------------
+| `url`              | URL to the artifact pushed to the artifact repository
+| `path`             | Absolute path to the artifact pushed to the artifact repository
+| `artifact-id`      | Maven artifact ID pushed to the artifact repository
+| `group-id`         | Maven group ID pushed to the artifact repository
+| `version`          | Version pushed to the artifact repository
 
 Examples
 --------
@@ -56,23 +60,29 @@ Example: Step Configuration (minimal)
     push-artifacts:
     - implementer: Maven
       config:
-        url: http://artifactory.company.com/repo
+        maven-push-artifact-repo-id: internal-id-name
+        maven-push-artifact-repo-url: url-to server
 
 Example: Generated Maven Deploy (uses both step configuration and previous results)
 
     mvn
       deploy:deploy-file'
-      -Durl=url
+      -Durl=maven-push-artifact-repo-url
       -Dversion=generate-metadata.version
       -DgroupId=package.artifact.group-id
       -DartifactId=package.artifact.artifact-id
       -Dfile=package.artifact.path
       -Dpackaging=package.artifact.package-type
+      -DrepositoryId=maven-push-artifact-repo-id
 
 Example: Results
 
     'tssc-results': {
-        'artifacts': [
+        'result: {
+            'success': True
+            'message': 'push artifacts step completed - see report-artifacts',
+        }
+        'report-artifacts': [
              {
              'path':''
              'artifact-id': ''
@@ -84,19 +94,18 @@ Example: Results
     }
 
 """
-import re
 import sys
 import sh
 
 from tssc import StepImplementer
+from tssc.config import ConfigValue
+
+from tssc.utils.maven import generate_maven_settings
 
 DEFAULT_CONFIG = {}
-AUTHENTICATION_CONFIG = {
-    'user': None,
-    'password': None
-}
 REQUIRED_CONFIG_KEYS = [
-    'url'
+    'maven-push-artifact-repo-url',
+    'maven-push-artifact-repo-id'
 ]
 
 
@@ -137,27 +146,35 @@ class Maven(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _validate_runtime_step_config(self, runtime_step_config):
-        """
-        Validates the given `runtime_step_config` against the required step configuration keys.
+    def _get_version(self):
+        # Required: Get the generate-metadata.version
+        if (self.get_step_results('generate-metadata') and
+                self.get_step_results('generate-metadata').get('version')):
+            return self.get_step_results('generate-metadata')['version']
+        raise ValueError('generate-metadata results missing version')
 
-        Parameters
-        ----------
-        runtime_step_config : dict
-            Step configuration to use when the StepImplementer runs the step with all of the
-            various static, runtime, defaults, and environment configuration munged together.
+    def _get_artifacts(self):
+        # Required: Get the package.artifacts
+        if (self.get_step_results('package') and
+                self.get_step_results('package').get('artifacts')):
+            return self.get_step_results('package')['artifacts']
+        raise ValueError('package results missing artifacts')
 
-        Raises
-        ------
-        AssertionError
-            If the given `runtime_step_config` is not valid with a message as to why.
-        """
-        super()._validate_runtime_step_config(runtime_step_config) #pylint: disable=protected-access
-
-        assert ( \
-            all(element in runtime_step_config for element in AUTHENTICATION_CONFIG) or \
-            not any(element in runtime_step_config for element in AUTHENTICATION_CONFIG) \
-        ), 'Either username or password is not set. Neither or both must be set.'
+    def _settings_file(self):
+        # ----- build settings.xml
+        maven_servers = ConfigValue.convert_leaves_to_values(
+            self.get_config_value('maven-servers')
+        )
+        maven_repositories = ConfigValue.convert_leaves_to_values(
+            self.get_config_value('maven-repositories')
+        )
+        maven_mirrors = ConfigValue.convert_leaves_to_values(
+            self.get_config_value('maven-mirrors')
+        )
+        return generate_maven_settings(self.create_working_folder(),
+                                       maven_servers,
+                                       maven_repositories,
+                                       maven_mirrors)
 
     def _run_step(self):
         """Runs the TSSC step implemented by this StepImplementer.
@@ -167,47 +184,18 @@ class Maven(StepImplementer):
         dict
             Results of running this step.
         """
-        user = ''
-        password = ''
-
-        url = self.get_config_value('url')
-
-        if self.has_config_value(AUTHENTICATION_CONFIG):
-            if(self.get_config_value('user') and self.get_config_value('password')):
-                user = self.get_config_value('user')
-                password = self.get_config_value('password')
 
         # ----- get generate-metadata items
-        # Required: Get the generate-metadata.version
-        if (self.get_step_results('generate-metadata') and
-                self.get_step_results('generate-metadata').get('version')):
-            version = self.get_step_results('generate-metadata')['version']
-        else:
-            raise ValueError('Severe error: Generate-metadata does not have a version')
+        version = self._get_version()
 
-        # ----- get package items this will change
-        # Required: Get the package.artifacts
-        if (self.get_step_results('package') and
-                self.get_step_results('package').get('artifacts')):
-            artifacts = self.get_step_results('package')['artifacts']
-        else:
-            raise ValueError('Severe error: Package does not have artifacts')
+        # ----- get package items
+        artifacts = self._get_artifacts()
 
-        # Build a temporary settings.xml file for the mvn user/pass
-        settings_path = self.write_working_file('ci-settings.xml', b'''
-        <settings>
-              <servers>
-                  <server>
-                          <id>${repositoryId}</id>
-                          <username>${repositoryUser}</username>
-                          <password>${repositoryPassword}</password>
-                  </server>
-              </servers>
-        </settings>''')
+        maven_push_artifact_repo_id = self.get_config_value('maven-push-artifact-repo-id')
+        maven_push_artifact_repo_url = self.get_config_value('maven-push-artifact-repo-url')
+        settings_file = self._settings_file()
 
-        results = {
-            'artifacts': []
-        }
+        report_artifacts = []
 
         for artifact in artifacts:
             artifact_path = artifact['path']
@@ -216,56 +204,33 @@ class Maven(StepImplementer):
             package_type = artifact['package-type']
 
             try:
-                # Build the mvn command, settings is required even if no user/password
-                # The settings file is required, need to deal with empty userid,password
-                # https://maven.apache.org/plugins/maven-deploy-plugin/deploy-file-mojo.html
-
-                if user == '':
-                    sh.mvn(  # pylint: disable=no-member
-                        'deploy:deploy-file',
-                        '-Dversion=' + version,
-                        '-Durl=' + url,
-                        '-Dfile=' + artifact_path,
-                        '-DgroupId=' + group_id,
-                        '-DartifactId=' + artifact_id,
-                        '-Dpackaging=' + package_type,
-                        '-DrepositoryId=tssc',
-                        '-s' + settings_path,
-                        _out=sys.stdout,
-                        _err=sys.stderr
-                    )
-                else:
-                    sh.mvn(  # pylint: disable=no-member
-                        'deploy:deploy-file',
-                        '-Dversion=' + version,
-                        '-Durl=' + url,
-                        '-Dfile=' + artifact_path,
-                        '-DgroupId=' + group_id,
-                        '-DartifactId=' + artifact_id,
-                        '-Dpackaging=' + package_type,
-                        '-DrepositoryId=tssc',
-                        '-DrepositoryUser=' + user,
-                        '-DrepositoryPassword=' + password,
-                        '-s' + settings_path,
-                        _out=sys.stdout,
-                        _err=sys.stderr
-                    )
-
+                sh.mvn(  # pylint: disable=no-member
+                    'deploy:deploy-file',
+                    '-Dversion=' + version,
+                    '-Dfile=' + artifact_path,
+                    '-DgroupId=' + group_id,
+                    '-DartifactId=' + artifact_id,
+                    '-Dpackaging=' + package_type,
+                    '-Durl=' + maven_push_artifact_repo_url,
+                    '-DrepositoryId=' + maven_push_artifact_repo_id,
+                    '-s' + settings_file,
+                    _out=sys.stdout,
+                    _err=sys.stderr
+                )
             except sh.ErrorReturnCode as error:
-                raise RuntimeError("Error invoking mvn: {all}".format(all=error)) from error
+                raise RuntimeError(f'Error invoking mvn: {error}') from error
 
-            results['artifacts'].append({
-                'url': url + '/' +
-                       re.sub(r'\.', '/', group_id) + '/' +
-                       artifact_id + '/' +
-                       version + '/' +
-                       artifact_id + '-' +
-                       version + '.' +
-                       package_type,
+            report_artifacts.append({
                 'artifact-id': artifact_id,
                 'group-id': group_id,
                 'version': version,
                 'path': artifact_path,
             })
-
+        results = {
+            'result': {
+                'success': True,
+                'message': 'push artifacts step completed - see report-artifacts',
+            },
+            'report-artifacts': report_artifacts
+        }
         return results

--- a/tssc/step_implementers/uat/maven.py
+++ b/tssc/step_implementers/uat/maven.py
@@ -96,8 +96,6 @@ REQUIRED_CONFIG_KEYS = [
 ]
 
 
-
-
 class Maven(StepImplementer):
     """
     StepImplementer for the unit-test step for Maven generating Cucumber reports.

--- a/tssc/step_implementers/uat/maven.py
+++ b/tssc/step_implementers/uat/maven.py
@@ -210,15 +210,14 @@ class Maven(StepImplementer):
                 os.path.dirname(os.path.abspath(pom_file)),
                 'target/surefire-reports')
 
-
         try:
             sh.mvn(  # pylint: disable=no-member
                 'clean',
                 '-Pintegration-test',
                 f'-Dselenium.hub.url={selenium_hub_url}',
                 f'-Dtarget.base.url={target_base_url}',
-                f'-Dcucumber.plugin=html:target/{report_dir}/cucumber.html,'\
-                f'json:target/{report_dir}/cucumber.json',
+                f'-Dcucumber.plugin=html:target/{report_dir}/cucumber.html,' \
+                    f'json:target/{report_dir}/cucumber.json',
                 'test',
                 '-f', pom_file,
                 '-s', settings_file,
@@ -258,8 +257,8 @@ class Maven(StepImplementer):
                 'report-artifacts': [
                     {
                         'name': 'Uat results generated',
-                        'path': f'file://{os.path.dirname(os.path.abspath(pom_file))}' +
-                                f'/target/{report_dir}'
+                        'path': f'file://{os.path.dirname(os.path.abspath(pom_file))}' \
+                            f'/target/{report_dir}'
                     }
                 ]
             }

--- a/tssc/step_implementers/uat/maven.py
+++ b/tssc/step_implementers/uat/maven.py
@@ -156,7 +156,7 @@ class Maven(StepImplementer):
 
         return target_base_url
 
-    def _settings_file(self):
+    def _generate_maven_settings(self):
         # ----- build settings.xml
         maven_servers = ConfigValue.convert_leaves_to_values(
             self.get_config_value('maven-servers')
@@ -181,7 +181,7 @@ class Maven(StepImplementer):
         dict
             Results of running this step.
         """
-        settings_file = self._settings_file()
+        settings_file = self._generate_maven_settings()
         pom_file = self.get_config_value('pom-file')
         fail_on_no_tests = self.get_config_value('fail-on-no-tests')
         selenium_hub_url = self.get_config_value('selenium-hub-url')

--- a/tssc/step_implementers/unit_test/maven.py
+++ b/tssc/step_implementers/unit_test/maven.py
@@ -122,7 +122,7 @@ class Maven(StepImplementer):
         """
         return REQUIRED_CONFIG_KEYS
 
-    def _settings_file(self):
+    def _generate_maven_settings(self):
         # ----- build settings.xml
         maven_servers = ConfigValue.convert_leaves_to_values(
             self.get_config_value('maven-servers')
@@ -173,7 +173,7 @@ class Maven(StepImplementer):
                 os.path.dirname(os.path.abspath(pom_file)),
                 'target/surefire-reports')
 
-        settings_file = self._settings_file()
+        settings_file = self._generate_maven_settings()
 
         try:
             sh.mvn(  # pylint: disable=no-member

--- a/tssc/step_implementers/unit_test/maven.py
+++ b/tssc/step_implementers/unit_test/maven.py
@@ -82,9 +82,6 @@ REQUIRED_CONFIG_KEYS = [
 ]
 
 
-
-
-
 class Maven(StepImplementer):
     """
     StepImplementer for the unit-test step for Maven generating JUnit reports.

--- a/tssc/utils/__init__.py
+++ b/tssc/utils/__init__.py
@@ -6,10 +6,12 @@ from .file import *
 from .io import *
 from .reflection import *
 from .xml import *
+from .maven import *
 
 __all__ = [
     'file',
     'io',
     'reflection',
-    'xml'
+    'xml',
+    'maven'
 ]

--- a/tssc/utils/maven.py
+++ b/tssc/utils/maven.py
@@ -5,7 +5,6 @@ Shared utils for maven deeds
 import xml.etree.ElementTree as ET
 
 def generate_maven_settings(working_dir, maven_servers, maven_repositories, maven_mirrors):
-
     """
     Generates and returns a settings.xml file from the inputs it is provided.
 
@@ -42,10 +41,9 @@ def generate_maven_settings(working_dir, maven_servers, maven_repositories, mave
 
     tree = ET.ElementTree(root)
 
-    with open(working_dir + '/settings.xml', 'wb') as files:
-        tree.write(files)
-
     settings_path = working_dir + '/settings.xml'
+    with open(settings_path, 'wb') as file:
+        tree.write(file)
 
     return settings_path
 

--- a/tssc/utils/maven.py
+++ b/tssc/utils/maven.py
@@ -1,0 +1,128 @@
+"""
+Shared utils for maven deeds
+"""
+
+import xml.etree.ElementTree as ET
+
+def generate_maven_settings(working_dir, maven_servers, maven_repositories, maven_mirrors):
+
+    """
+    Generates and returns a settings.xml file from the inputs it is provided.
+
+    Parameters
+    ----------
+    :
+    maven_servers:
+        Dictionary of id, username, password
+    maven_repositories:
+        Dictionary of id, url, snapshots, releases
+    maven_mirrors:
+        Dictionary of id, url, mirror_of
+
+    Returns
+    -------
+    dict
+        Dictionary parsed from given YAML or JSON file
+
+    Raises
+    ------
+    ValueError
+        If the given file can not be parsed as YAML or JSON.
+
+    Returns
+    -------
+    Str
+        The path to the settings.xml that was generated.
+    """
+
+    root = ET.Element('settings')
+    generate_maven_servers(root, maven_servers)
+    generate_maven_repositories(root, maven_repositories)
+    generate_maven_mirrors(root, maven_mirrors)
+
+    tree = ET.ElementTree(root)
+
+    with open(working_dir + '/settings.xml', 'wb') as files:
+        tree.write(files)
+
+    settings_path = working_dir + '/settings.xml'
+
+    return settings_path
+
+def generate_maven_servers(ElementTree, maven_servers): # pylint: disable=invalid-name
+    """
+    Generates maven servers section of settings.xml
+    """
+
+    if maven_servers is not None:
+        servers = ET.Element('servers')
+        ElementTree.append(servers)
+        for server in maven_servers:
+            if server.get('id'):
+                server_element = ET.Element('server')
+                servers.append(server_element)
+                server_id = ET.SubElement(server_element, 'id')
+                server_id.text = server['id']
+                if server.get('username') and server.get('password'):
+                    server_username = ET.SubElement(server_element, 'username')
+                    server_username.text = server['username']
+                    server_password = ET.SubElement(server_element, 'password')
+                    server_password.text = server['password']
+                else:
+                    if server.get('username') or server.get('password'):
+                        raise ValueError('username and password are required for maven_servers.')
+            else:
+                raise ValueError('id is required for maven_servers.')
+
+def generate_maven_repositories(ElementTree, maven_repositories): # pylint: disable=invalid-name
+    """
+    Generates maven repositories section of settings.xml
+    """
+
+    if maven_repositories is not None:
+        profiles = ET.Element('profiles')
+        ElementTree.append (profiles)
+        profile = ET.Element('profile')
+        profiles.append (profile)
+        repositories = ET.Element('repositories')
+        profile.append(repositories)
+
+        for repository in maven_repositories:
+            if repository.get('id') and repository.get('url'):
+                repository_element = ET.Element('repository')
+                repositories.append(repository_element)
+                repository_id = ET.SubElement(repository_element, 'id')
+                repository_id.text = repository['id']
+                repository_url = ET.SubElement(repository_element, 'url')
+                repository_url.text = repository['url']
+                if repository.get('releases'):
+                    repository_releases = ET.SubElement(repository_element, 'releases')
+                    repository_releases_enabled = ET.SubElement(repository_releases, 'enabled')
+                    repository_releases_enabled.text = repository['releases']
+                if repository.get('snapshots'):
+                    repository_snapshots = ET.SubElement(repository_element, 'snapshots')
+                    repository_snapshots_enabled = ET.SubElement(repository_snapshots, 'enabled')
+                    repository_snapshots_enabled.text = repository['snapshots']
+            else:
+                raise ValueError('id and url are required for maven_repositories.')
+
+def generate_maven_mirrors(ElementTree, maven_mirrors): # pylint: disable=invalid-name
+    """
+    Generates maven mirrors section of settings.xml
+    """
+
+    if maven_mirrors is not None:
+        mirrors = ET.Element('mirrors')
+        ElementTree.append(mirrors)
+        for mirror in maven_mirrors:
+            if mirror.get('id') and mirror.get('url') and mirror.get('mirror-of'):
+                mirror_element = ET.Element('mirror')
+                mirrors.append(mirror_element)
+                mirror_id = ET.SubElement(mirror_element, 'id')
+                mirror_id.text = mirror['id']
+                mirror_url = ET.SubElement(mirror_element, 'url')
+                mirror_url.text = mirror['url']
+                mirror_mirror_of = ET.SubElement(mirror_element, 'mirrorOf')
+                mirror_mirror_of.text = mirror['mirror-of']
+            else:
+                raise ValueError('id, url and mirrorOf are required for maven_mirrors.')

--- a/tssc/utils/maven.py
+++ b/tssc/utils/maven.py
@@ -10,18 +10,12 @@ def generate_maven_settings(working_dir, maven_servers, maven_repositories, mave
 
     Parameters
     ----------
-    :
     maven_servers:
         Dictionary of id, username, password
     maven_repositories:
         Dictionary of id, url, snapshots, releases
     maven_mirrors:
         Dictionary of id, url, mirror_of
-
-    Returns
-    -------
-    dict
-        Dictionary parsed from given YAML or JSON file
 
     Raises
     ------
@@ -49,7 +43,17 @@ def generate_maven_settings(working_dir, maven_servers, maven_repositories, mave
 
 def generate_maven_servers(ElementTree, maven_servers): # pylint: disable=invalid-name
     """
-    Generates maven servers section of settings.xml
+    Generates maven servers section of settings.xml and appends to the file 
+
+    Parameters
+    ----------
+    maven_servers:
+        Dictionary of id, username, password
+
+    Raises
+    ------
+    ValueError
+        If required fields are not provided a value.
     """
 
     if maven_servers is not None:
@@ -74,7 +78,17 @@ def generate_maven_servers(ElementTree, maven_servers): # pylint: disable=invali
 
 def generate_maven_repositories(ElementTree, maven_repositories): # pylint: disable=invalid-name
     """
-    Generates maven repositories section of settings.xml
+    Generates maven repositories section of settings.xml and appends to the file
+
+    Parameters
+    ----------
+    maven_repositories:
+        Dictionary of id, username, password
+
+    Raises
+    ------
+    ValueError
+        If required fields are not provided a value.
     """
 
     if maven_repositories is not None:
@@ -106,7 +120,17 @@ def generate_maven_repositories(ElementTree, maven_repositories): # pylint: disa
 
 def generate_maven_mirrors(ElementTree, maven_mirrors): # pylint: disable=invalid-name
     """
-    Generates maven mirrors section of settings.xml
+    Generates maven mirrors section of settings.xml and appends to the file
+
+    Parameters
+    ----------
+    maven_mirrors:
+        Dictionary of id, username, password
+
+    Raises
+    ------
+    ValueError
+        If required fields are not provided a value.
     """
 
     if maven_mirrors is not None:

--- a/tssc/utils/xml.py
+++ b/tssc/utils/xml.py
@@ -67,8 +67,6 @@ def get_xml_element_by_path(xml_file_path, xpath, default_namespace=None, xml_na
 
     Returns
     -------
-    None
-        No element was found
     xml.etree.ElementTree.Element
         The Element found given the xpath
     """


### PR DESCRIPTION
Goal:  To create a settings.xml file for each of the maven step_implementers:
(1)  push_artifacts
(2)  package
(3)  uat
(4)  unit_test
Changes:
- use the 'new' sops for passwords...
- create a utils/maven to create settings.xml
- update uat to use -s settings.xml
- update package to use -s settings.xml
- REWORK push artifacts to use -s settings.xml 
  remove user/password
  add repo
Note that test/step_implementer/unit_test/test_maven.py was renamed to test_maven_unit_test.py because of the newly created util/tests/test_maven.py (unique file names for the tests.)