### PR TITLE
NAPSSPO-1029 - tssc-python-library - tag-source (Git) - if url not provided and CI tool checks out source using username and tssc config provides a username/pass then everything breaks

### DIFF
--- a/tssc/step_implementer.py
+++ b/tssc/step_implementer.py
@@ -52,13 +52,13 @@ class StepImplementer(ABC): # pylint: disable=too-many-instance-attributes
         Path to the directory to write step working files to
     step_environment_config : dict, optional
         Step configuration specific to the current environment.
-    config : TSSCSubStepConfig
+    config : SubStepConfig
         Configuration for this step.
     environment : str
         Environment name to execute this step against
 
     Attributes
-    __config : TSSCSubStepConfig
+    __config : SubStepConfig
     __environment : str
     """
 
@@ -88,7 +88,7 @@ class StepImplementer(ABC): # pylint: disable=too-many-instance-attributes
         """
         Returns
         -------
-        TSSCSubStepConfig
+        SubStepConfig
             Configuration for this step.
         """
         return self.__config


### PR DESCRIPTION
* tssc/step_implementers/tag_source/git.py::Git::_git_url - remove ANYTHING@ from git url before returning so that when passing in our own username/password does not conflict

## integration test:
* https://test-jenkins-unprivilaged.apps.tssc.rht-set.com/job/tssc-references/job/tssc-reference-app-quarkus-rest-json/job/feature%252FNAPSSPO-1018/11/console