### PR TITLE
NAPSSPO-2018 & NAPSSPO-1025 - get rid of need for privilaged containers for buildah and openscap

### DIFF
--- a/tests/step_implementers/create_container_image/test_buildah.py
+++ b/tests/step_implementers/create_container_image/test_buildah.py
@@ -171,6 +171,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
             }}
             run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
             buildah_mock.bud.assert_called_once_with(
+                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers',
@@ -248,6 +249,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                 config,
                 expected_step_results)
             buildah_mock.bud.assert_called_once_with(
+                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers',
@@ -303,6 +305,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
             }}
             run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
             buildah_mock.bud.assert_called_once_with(
+                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers',
@@ -315,6 +318,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                 _tee='err'
             )
             buildah_mock.push.assert_called_once_with(
+                '--storage-driver=vfs',
                 tag,
                 'docker-archive:{image_tar_file}'.format(image_tar_file=image_tar_file),
                 _out=Any(IOBase),
@@ -402,6 +406,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
             }}
             run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
             buildah_mock.bud.assert_called_once_with(
+                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers',
@@ -414,6 +419,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                 _tee='err'
             )
             buildah_mock.push.assert_called_once_with(
+                '--storage-driver=vfs',
                 tag,
                 'docker-archive:{image_tar_file}'.format(image_tar_file=image_tar_file),
                 _out=Any(IOBase),
@@ -481,6 +487,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
             }}
             run_step_test_with_result_validation(temp_dir, 'create-container-image', config, expected_step_results)
             buildah_mock.bud.assert_called_once_with(
+                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers',

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -174,7 +174,12 @@ class Buildah(StepImplementer):
             )
 
             # perform build
+            #
+            # NOTE: using --storage-driver=vfs so that container does not need escalated privileges
+            #       vfs is less efficient then fuse (which would require host mounts),
+            #       but such is the price we pay for security.
             sh.buildah.bud(  # pylint: disable=no-member
+                '--storage-driver=vfs',
                 '--format=' + self.get_config_value('format'),
                 '--tls-verify=' + str(self.get_config_value('tlsverify')),
                 '--layers', '-f', image_spec_file,
@@ -199,9 +204,14 @@ class Buildah(StepImplementer):
             # Check to see if the tar docker-archive file already exists
             #   this needs to be run as buildah does not support overwritting
             #   existing files.
+            #
+            # NOTE: using --storage-driver=vfs so that container does not need escalated privileges
+            #       vfs is less efficient then fuse (which would require host mounts),
+            #       but such is the price we pay for security.
             if os.path.exists(image_tar_file):
                 os.remove(image_tar_file)
             sh.buildah.push( #pylint: disable=no-member
+                '--storage-driver=vfs',
                 tag,
                 "docker-archive:" + image_tar_file,
                 _out=sys.stdout,


### PR DESCRIPTION
## Dependencies
* This has https://github.com/rhtconsulting/tssc-python-package/pull/84 in it so that it can be tested therefor https://github.com/rhtconsulting/tssc-python-package/pull/84 should be reviewed and merged first
* needs images from https://github.com/rhtconsulting/tssc-containers/pull/26

## effects
* https://github.com/rhtconsulting/tssc-jenkins-library/pull/11

## integration test:
* https://test-jenkins-unprivilaged.apps.tssc.rht-set.com/job/tssc-references/job/tssc-reference-app-quarkus-rest-json/job/feature%252FNAPSSPO-1018/11/console