### PR TITLE
NAPSSPO-1037, NAPSSPO-1038, NAPSSPO-870, & NAPSSPO-1027

### DIFF
--- a/tests/helpers/base_step_implementer_test_case.py
+++ b/tests/helpers/base_step_implementer_test_case.py
@@ -1,0 +1,45 @@
+import os
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+import yaml
+from tssc import TSSCFactory
+
+from .base_tssc_test_case import BaseTSSCTestCase
+
+
+class BaseStepImplementerTestCase(BaseTSSCTestCase):
+    def run_step_test_with_result_validation(
+        self,
+        temp_dir,
+        step_name,
+        config,
+        expected_step_results,
+        runtime_args=None,
+        environment=None,
+        expected_stdout=None,
+        expected_stderr=None
+    ):
+        results_dir_path = os.path.join(temp_dir.path, 'tssc-results')
+        working_dir_path = os.path.join(temp_dir.path, 'tssc-working')
+
+        factory = TSSCFactory(config, results_dir_path, work_dir_path=working_dir_path)
+        if runtime_args:
+            factory.config.set_step_config_overrides(step_name, runtime_args)
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            factory.run_step(step_name, environment)
+
+        if expected_stdout is not None:
+            self.assertRegex(out.getvalue(), expected_stdout)
+
+        if expected_stderr is not None:
+            self.assertRegex(err.getvalue(), expected_stderr)
+
+        results_file_name = "tssc-results.yml"
+        with open(os.path.join(results_dir_path, results_file_name), 'r') as step_results_file:
+            actual_step_results = yaml.safe_load(step_results_file.read())
+
+            self.assertEqual(actual_step_results, expected_step_results)

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -1,6 +1,29 @@
-import io
 import os
+import yaml
 import re
+from tssc import TSSCFactory
+
+def run_step_test_with_result_validation(
+        temp_dir,
+        step_name,
+        config,
+        expected_step_results,
+        runtime_args=None,
+        environment=None):
+
+    results_dir_path = os.path.join(temp_dir.path, 'tssc-results')
+    working_dir_path = os.path.join(temp_dir.path, 'tssc-working')
+
+    factory = TSSCFactory(config, results_dir_path, work_dir_path=working_dir_path)
+    if runtime_args:
+        factory.config.set_step_config_overrides(step_name, runtime_args)
+
+    factory.run_step(step_name, environment)
+
+    results_file_name = "tssc-results.yml"
+    with open(os.path.join(results_dir_path, results_file_name), 'r') as step_results_file:
+        actual_step_results = yaml.safe_load(step_results_file.read())
+        assert actual_step_results == expected_step_results
 
 def create_git_commit_with_sample_file(temp_dir, git_repo, sample_file_name = 'sample-file', commit_message = 'test'):
     sample_file = os.path.join(temp_dir.path, sample_file_name)

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -1,29 +1,6 @@
+import io
 import os
-import yaml
 import re
-from tssc import TSSCFactory
-
-def run_step_test_with_result_validation(
-        temp_dir,
-        step_name,
-        config,
-        expected_step_results,
-        runtime_args=None,
-        environment=None):
-
-    results_dir_path = os.path.join(temp_dir.path, 'tssc-results')
-    working_dir_path = os.path.join(temp_dir.path, 'tssc-working')
-
-    factory = TSSCFactory(config, results_dir_path, work_dir_path=working_dir_path)
-    if runtime_args:
-        factory.config.set_step_config_overrides(step_name, runtime_args)
-
-    factory.run_step(step_name, environment)
-
-    results_file_name = "tssc-results.yml"
-    with open(os.path.join(results_dir_path, results_file_name), 'r') as step_results_file:
-        actual_step_results = yaml.safe_load(step_results_file.read())
-        assert actual_step_results == expected_step_results
 
 def create_git_commit_with_sample_file(temp_dir, git_repo, sample_file_name = 'sample-file', commit_message = 'test'):
     sample_file = os.path.join(temp_dir.path, sample_file_name)

--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -1,12 +1,14 @@
 import os
 from unittest.mock import patch
+
 import sh
 from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
-from tests.helpers.test_utils import run_step_test_with_result_validation
 
 
-class TestStepImplementerPushArtifact(BaseTSSCTestCase):
+class TestStepImplementerPushArtifact(BaseStepImplementerTestCase):
 
     # ------------ SIMPLE tests that test the config required items
     @patch('sh.mvn', create=True)
@@ -24,7 +26,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
             with self.assertRaisesRegex(
                     AssertionError,
                     'The .* configuration .* is missing .*maven-push-artifact-repo-id.*'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+                self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                      config, expected_step_results, runtime_args)
 
     # ------------  Tests that require generate-metadata
@@ -52,7 +54,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     'generate-metadata results missing version'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+                self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                      config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
@@ -93,7 +95,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     'package results missing artifacts'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+                self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                      config, expected_step_results, runtime_args)
 
 
@@ -181,7 +183,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
                     }
             }
 
-            run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+            self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                  config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
@@ -273,7 +275,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
             with self.assertRaisesRegex(
                     RuntimeError,
                     'Error invoking mvn'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+                self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                      config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
@@ -365,7 +367,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
                             }
                     }
             }
-            run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+            self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                  config, expected_step_results, runtime_args)
     @patch('sh.mvn', create=True)
     def test_push_artifact_with_artifacts_results_multi(self, mvn_mock):
@@ -465,7 +467,7 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
                             }
                     }
             }
-            run_step_test_with_result_validation(temp_dir, 'push-artifacts',
+            self.run_step_test_with_result_validation(temp_dir, 'push-artifacts',
                                                  config, expected_step_results, runtime_args)
 
     @patch('sh.mvn', create=True)
@@ -561,7 +563,13 @@ class TestStepImplementerPushArtifact(BaseTSSCTestCase):
                     }
             }
             with self.assertRaisesRegex(
-                    ValueError,
-                    'id is required for maven_servers.'):
-                run_step_test_with_result_validation(temp_dir, 'push-artifacts',
-                                                     config, expected_step_results, runtime_args)
+                AssertionError,
+                r"Configuration for maven servers must specify a 'id':"
+                r" {'username': 'USER1', 'password': 'PW1'}"
+            ):
+                self.run_step_test_with_result_validation(
+                    temp_dir,
+                    'push-artifacts',
+                    config,
+                    expected_step_results, runtime_args
+                )

--- a/tests/step_implementers/validate_environment_configuration/test_configlint.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint.py
@@ -1,16 +1,16 @@
+
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import sh
 from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import BaseStepImplementerTestCase
+from tssc.step_implementers.validate_environment_configuration import \
+    Configlint
 
-from tests.helpers.test_utils import run_step_test_with_result_validation
 
-from tssc.step_implementers.validate_environment_configuration import Configlint
-
-
-class TestStepImplementerConfiglint(unittest.TestCase):
+class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_options_and_runtime(self, configlint_mock):
         with TempDirectory() as temp_dir:
@@ -59,7 +59,7 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     r'yml_path not specified in runtime args or in options'):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_options_and_runtime_and_steps(self, configlint_mock):
@@ -109,7 +109,7 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     r'yml_path not specified in runtime args or in options'):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
     @patch('sh.config_lint', create=True)
     def test_configlint_using_runtime(self, configlint_mock):
@@ -152,7 +152,7 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     AttributeError,
                     r'.*.'):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
     @patch('sh.config_lint', create=True)
     def test_configlint_ok(self, configlint_mock):
@@ -202,8 +202,26 @@ class TestStepImplementerConfiglint(unittest.TestCase):
                     }
                 }
             }
-            run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
-                                                 config, expected_step_results, runtime_args)
+
+            config_lint_stdout = 'success'
+            config_lint_result_mock = MagicMock()
+            config_lint_result_mock.stdout = config_lint_stdout
+
+            configlint_mock.side_effect = config_lint_stdout
+
+            expected_stdout = config_lint_stdout
+            expected_stderr = ""
+
+            self.run_step_test_with_result_validation(
+                temp_dir=temp_dir,
+                step_name='validate-environment-configuration',
+                config=config,
+                expected_step_results=expected_step_results,
+                runtime_args=runtime_args,
+                expected_stdout=expected_stdout,
+                expected_stderr=expected_stderr
+            )
+
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_rule(self, configlint_mock):
         with TempDirectory() as temp_dir:
@@ -251,7 +269,7 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     r'Rules file specified in tssc config not found: ./config-lint.rules'):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
 
     @patch('sh.config_lint', create=True)
@@ -303,7 +321,7 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     RuntimeError,
                     r'Error invoking config-lint: .*'):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
 
     @patch('sh.config_lint', create=True)
@@ -353,5 +371,5 @@ class TestStepImplementerConfiglint(unittest.TestCase):
             with self.assertRaisesRegex(
                     ValueError,
                     r'Specified file in yml_path not found: ' + yml_path):
-                run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
+                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)

--- a/tests/step_implementers/validate_environment_configuration/test_configlint.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint.py
@@ -1,32 +1,53 @@
 
 import os
+import re
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import sh
 from testfixtures import TempDirectory
-from tests.helpers.base_step_implementer_test_case import BaseStepImplementerTestCase
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+from tssc import TSSCException
 from tssc.step_implementers.validate_environment_configuration import \
     Configlint
 
-
 class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
+    @staticmethod
+    def create_config_lint_side_effect(
+        config_lint_stdout="",
+        config_lint_stderr="",
+        config_lint_fail=False
+    ):
+        def config_lint_side_effect(*args, **kwargs):
+            kwargs['_out'](config_lint_stdout)
+            kwargs['_err'](config_lint_stderr)
+
+            if config_lint_fail:
+                raise sh.ErrorReturnCode_255(
+                    'config-lint',
+                    bytes(config_lint_stdout, 'utf-8'),
+                    bytes(config_lint_stderr, 'utf-8')
+                )
+
+        return config_lint_side_effect
+
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_options_and_runtime(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
+            temp_dir.write('config-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
             tssc_results = '''tssc-results:
                 validate-environment-configuration:
                         'badoptions':
                             {
-                                'yml_path':''' + yml_path + '''
+                                'yml_path':''' + file_to_validate_file_path + '''
                             }
             '''
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'config-lint.rules')
             config = {
                 'tssc-config': {
@@ -48,7 +69,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                         ]
@@ -65,18 +86,18 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     def test_configlint_missing_options_and_runtime_and_steps(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
+            temp_dir.write('config-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
             tssc_results = '''tssc-results:
                 validate-environment-configuration:
                     'badoptions':
                             {
-                                'yml_path':''' + yml_path + '''
+                                'yml_path':''' + file_to_validate_file_path + '''
                             }
             '''
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'config-lint.rules')
             config = {
                 'tssc-config': {
@@ -98,7 +119,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                         ]
@@ -115,13 +136,13 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     def test_configlint_using_runtime(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path: str = os.path.join(temp_dir.path, 'file.yml')
+            temp_dir.write('config-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = os.path.join(temp_dir.path, 'config-file-to-validate.yml')
             tssc_results = '''tssc-results:
             '''
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'config-lint.rules')
             config = {
                 'tssc-config': {
@@ -134,7 +155,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 }
             }
             runtime_args = {
-                'yml_path': yml_path
+                'yml_path': file_to_validate_file_path
             }
             expected_step_results = {
                 'tssc-results': {
@@ -154,29 +175,64 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                     r'.*.'):
                 self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
                                                      config, expected_step_results, runtime_args)
+
     @patch('sh.config_lint', create=True)
     def test_configlint_ok(self, configlint_mock):
+        kube_label_app_expected_value = 'foo-app'
+
         with TempDirectory() as temp_dir:
-            yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
-            tssc_results = '''tssc-results:
-                validate-environment-configuration:
-                        'options':
-                            {
-                                'yml_path':''' + yml_path + '''
-                            }
-            '''
+            # write config file to validate
+            file_to_validate_contents = f"""---
+kind: Deployment
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: {kube_label_app_expected_value}
+"""
+            temp_dir.write('config-file-to-validate.yml', file_to_validate_contents.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
+
+            # write config-lint rules file
+            configlint_rules_content = f"""version: 1
+description: Rules for Kubernetes spec files
+type: Kubernetes
+files:
+  - "*.yml"
+
+rules:
+
+# Rule to check for sidecar annotation in Deployment
+- id: TSSC_TEST_EXAMPLE_LABEL
+  severity: FAILURE
+  message: Deployment example for a label
+  resource: Deployment
+  assertions:
+    - key: spec.template.metadata.labels.app
+      op: contains
+      value: '{kube_label_app_expected_value}'
+"""
+            config_lint_rules_file_name = 'config-lint-test-rules.yml'
+            temp_dir.write(config_lint_rules_file_name, configlint_rules_content.encode())
+            config_lint_rules_file_path = os.path.join(temp_dir.path, config_lint_rules_file_name)
+
+
+            # write results thus far
+            tssc_results = f"""---
+tssc-results:
+    validate-environment-configuration:
+        'options':
+            'yml_path': '{file_to_validate_file_path}'
+"""
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
-            rules = os.path.join(temp_dir.path, 'config-lint.rules')
+
             config = {
                 'tssc-config': {
                     'validate-environment-configuration': {
                         'implementer': 'Configlint',
                         'config': {
-                            'rules': rules
+                            'rules': config_lint_rules_file_path
                         }
                     }
                 }
@@ -191,7 +247,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                             {
@@ -204,13 +260,8 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             }
 
             config_lint_stdout = 'success'
-            config_lint_result_mock = MagicMock()
-            config_lint_result_mock.stdout = config_lint_stdout
-
-            configlint_mock.side_effect = config_lint_stdout
-
-            expected_stdout = config_lint_stdout
-            expected_stderr = ""
+            configlint_mock.side_effect = \
+                TestStepImplementerConfiglint.create_config_lint_side_effect(config_lint_stdout)
 
             self.run_step_test_with_result_validation(
                 temp_dir=temp_dir,
@@ -218,26 +269,26 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 config=config,
                 expected_step_results=expected_step_results,
                 runtime_args=runtime_args,
-                expected_stdout=expected_stdout,
-                expected_stderr=expected_stderr
+                expected_stdout=config_lint_stdout,
+                expected_stderr=None
             )
 
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_rule(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
-            tssc_results = '''tssc-results:
-                validate-environment-configuration:
-                        'options':
-                            {
-                                'yml_path':''' + yml_path + '''
-                            }
-            '''
+            temp_dir.write('config-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
+            # write results thus far
+            tssc_results = f"""---
+tssc-results:
+    validate-environment-configuration:
+        'options':
+            'yml_path': '{file_to_validate_file_path}'
+"""
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'badconfig-lint.rules')
             config = {
                 'tssc-config': {
@@ -259,7 +310,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                         ]
@@ -276,18 +327,20 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     def test_configlint_bad_sh_call(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('file.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
-            tssc_results = '''tssc-results:
-                validate-environment-configuration:
-                        'options':
-                            {
-                                'yml_path':''' + yml_path + '''
-                            }
-            '''
+            temp_dir.write('config-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
+
+            # write results thus far
+            tssc_results = f"""---
+tssc-results:
+    validate-environment-configuration:
+        'options':
+            'yml_path': '{file_to_validate_file_path}'
+"""
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'config-lint.rules')
             config = {
                 'tssc-config': {
@@ -309,7 +362,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                         ]
@@ -319,27 +372,34 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             sh.config_lint.side_effect = sh.ErrorReturnCode('config_lint',
                                                             b'mock stdout', b'mock error')
             with self.assertRaisesRegex(
-                    RuntimeError,
-                    r'Error invoking config-lint: .*'):
-                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
-                                                     config, expected_step_results, runtime_args)
+                RuntimeError,
+                r'Error invoking config-lint: .*'
+            ):
+                self.run_step_test_with_result_validation(
+                    temp_dir,
+                    'validate-environment-configuration',
+                    config,
+                    expected_step_results, runtime_args
+                )
 
     @patch('sh.config_lint', create=True)
     def test_configlint_missing_yml_file(self, configlint_mock):
         with TempDirectory() as temp_dir:
             yml_file = ''
-            temp_dir.write('badfile.yml', yml_file.encode())
-            yml_path = str(os.path.join(temp_dir.path, 'file.yml'))
-            tssc_results = '''tssc-results:
-                validate-environment-configuration:
-                        'options':
-                            {
-                                'yml_path':''' + yml_path + '''
-                            }
-            '''
+            temp_dir.write('badconfig-file-to-validate.yml', yml_file.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
+
+            # write results thus far
+            tssc_results = f"""---
+tssc-results:
+    validate-environment-configuration:
+        'options':
+            'yml_path': '{file_to_validate_file_path}'
+"""
             temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
-            configlint_rules = ''
-            temp_dir.write('config-lint.rules', configlint_rules.encode())
+
+            configlint_rules_content = ''
+            temp_dir.write('config-lint.rules', configlint_rules_content.encode())
             rules = os.path.join(temp_dir.path, 'config-lint.rules')
             config = {
                 'tssc-config': {
@@ -361,7 +421,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                             'message': 'configlint step completed'
                         },
                         'options': {
-                            'yml_path': yml_path
+                            'yml_path': file_to_validate_file_path
                         },
                         'report-artifacts': [
                         ]
@@ -369,7 +429,118 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 }
             }
             with self.assertRaisesRegex(
-                    ValueError,
-                    r'Specified file in yml_path not found: ' + yml_path):
-                self.run_step_test_with_result_validation(temp_dir, 'validate-environment-configuration',
-                                                     config, expected_step_results, runtime_args)
+                ValueError,
+                r'Specified file in yml_path not found: ' + file_to_validate_file_path
+            ):
+                self.run_step_test_with_result_validation(
+                    temp_dir,
+                    'validate-environment-configuration',
+                    config,
+                    expected_step_results, runtime_args
+                )
+
+    @patch('sh.config_lint', create=True)
+    def test_configlint_failed_validation(self, configlint_mock):
+        kube_label_app_expected_value = 'foo-app'
+
+        with TempDirectory() as temp_dir:
+            # write config file to validate
+            file_to_validate_contents = f"""---
+kind: Deployment
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: {kube_label_app_expected_value}
+"""
+            temp_dir.write('config-file-to-validate.yml', file_to_validate_contents.encode())
+            file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
+
+            # write config-lint rules file
+            configlint_rules_content = f"""version: 1
+description: Rules for Kubernetes spec files
+type: Kubernetes
+files:
+  - "*.yml"
+
+rules:
+
+# Rule to check for sidecar annotation in Deployment
+- id: TSSC_TEST_EXAMPLE_LABEL
+  severity: FAILURE
+  message: Deployment example for a label
+  resource: Deployment
+  assertions:
+    - key: spec.template.metadata.labels.app
+      op: contains
+      value: '{kube_label_app_expected_value}'
+"""
+            config_lint_rules_file_name = 'config-lint-test-rules.yml'
+            temp_dir.write(config_lint_rules_file_name, configlint_rules_content.encode())
+            config_lint_rules_file_path = os.path.join(temp_dir.path, config_lint_rules_file_name)
+
+
+            # write results thus far
+            tssc_results = f"""---
+tssc-results:
+    validate-environment-configuration:
+        'options':
+            'yml_path': '{file_to_validate_file_path}'
+"""
+            temp_dir.write('tssc-results/tssc-results.yml', tssc_results.encode())
+
+            config = {
+                'tssc-config': {
+                    'validate-environment-configuration': {
+                        'implementer': 'Configlint',
+                        'config': {
+                            'rules': config_lint_rules_file_path
+                        }
+                    }
+                }
+            }
+            runtime_args = {
+            }
+            expected_step_results = {
+                'tssc-results': {
+                    'validate-environment-configuration': {
+                        'result': {
+                            'success': True,
+                            'message': 'configlint step completed'
+                        },
+                        'options': {
+                            'yml_path': file_to_validate_file_path
+                        },
+                        'report-artifacts': [
+                            {
+                                'name' : 'configlint-result-set',
+                                'path': f'file://{temp_dir.path}/tssc-working/validate-environment-configuration/configlint_results_file.txt'
+                            }
+                        ]
+                    }
+                }
+            }
+
+            config_lint_stdout = "mock stdout"
+            config_lint_stderr = "mock stderr - validation error"
+            configlint_mock.side_effect = \
+                TestStepImplementerConfiglint.create_config_lint_side_effect(
+                    config_lint_stdout=config_lint_stdout,
+                    config_lint_stderr=config_lint_stderr,
+                    config_lint_fail=True
+                )
+
+            with self.assertRaisesRegex(
+                TSSCException,
+                r'Failed config-lint scan. See standard out and standard error.'
+            ):
+                self.run_step_test_with_result_validation(
+                    temp_dir=temp_dir,
+                    step_name='validate-environment-configuration',
+                    config=config,
+                    expected_step_results=expected_step_results,
+                    runtime_args=runtime_args,
+                    expected_stdout=config_lint_stdout,
+                    expected_stderr=config_lint_stderr
+                )

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -22,14 +22,17 @@ class TestCreateSHRedirectToMultipleStreamsFNCallback(BaseTSSCTestCase):
 
     def test_two_streams(self):
         stream_one = StringIO()
+        stream_two = StringIO()
         sh_redirect_to_multiple_streams_fn_callback = \
             create_sh_redirect_to_multiple_streams_fn_callback([
-                stream_one
+                stream_one,
+                stream_two
             ])
 
         sh_redirect_to_multiple_streams_fn_callback('data1')
 
         self.assertEqual('data1', stream_one.getvalue())
+        self.assertEqual('data1', stream_two.getvalue())
 
 class TestTextIOSelectiveObfuscator(BaseTSSCTestCase):
     def run_test(self, input, expected, randomize_replacment_length=False, obfuscation_targets=None, replacment_char=None):

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,10 +1,35 @@
-import sys
 import io
+import sys
 from contextlib import redirect_stdout
-
-from tssc.utils.io import TextIOSelectiveObfuscator, TextIOIndenter
+from io import StringIO
 
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
+from tssc.utils.io import (TextIOIndenter, TextIOSelectiveObfuscator,
+                           create_sh_redirect_to_multiple_streams_fn_callback)
+
+
+class TestCreateSHRedirectToMultipleStreamsFNCallback(BaseTSSCTestCase):
+    def test_one_stream(self):
+        stream_one = StringIO()
+        sh_redirect_to_multiple_streams_fn_callback = \
+            create_sh_redirect_to_multiple_streams_fn_callback([
+                stream_one
+            ])
+
+        sh_redirect_to_multiple_streams_fn_callback('data1')
+
+        self.assertEqual('data1', stream_one.getvalue())
+
+    def test_two_streams(self):
+        stream_one = StringIO()
+        sh_redirect_to_multiple_streams_fn_callback = \
+            create_sh_redirect_to_multiple_streams_fn_callback([
+                stream_one
+            ])
+
+        sh_redirect_to_multiple_streams_fn_callback('data1')
+
+        self.assertEqual('data1', stream_one.getvalue())
 
 class TestTextIOSelectiveObfuscator(BaseTSSCTestCase):
     def run_test(self, input, expected, randomize_replacment_length=False, obfuscation_targets=None, replacment_char=None):

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -2,9 +2,12 @@
 
 Test for the utility for maven operations.
 """
+import xml.etree.ElementTree as ET
+from io import BytesIO
+
 from testfixtures import TempDirectory
 from tests.helpers.base_tssc_test_case import BaseTSSCTestCase
-from tssc.utils.maven import generate_maven_settings
+from tssc.utils.maven import *
 
 
 class TestMavenUtils(BaseTSSCTestCase):
@@ -25,10 +28,9 @@ class TestMavenUtils(BaseTSSCTestCase):
             generate_maven_settings(temp_dir.path, maven_servers, None, None)
             with open(temp_dir.path + '/settings.xml', 'r') as tester:
                 results = tester.read()
-                assert results == settings
+                self.assertEquals(results, settings)
 
     def test_generate_maven_servers_id_does_not_exist(self):
-        
         maven_servers = [
             {
                 "username": "user1",
@@ -36,7 +38,11 @@ class TestMavenUtils(BaseTSSCTestCase):
             }
         ]
         with TempDirectory() as temp_dir:
-            with self.assertRaisesRegex(ValueError, 'id is required for maven_servers.'):
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"Configuration for maven servers must specify a 'id':"
+                r" {'username': 'user1', 'password': 'password1'}"
+            ):
                 generate_maven_settings(temp_dir.path, maven_servers, None, None)
 
     def test_generate_maven_servers_username_does_not_exist(self):
@@ -47,8 +53,11 @@ class TestMavenUtils(BaseTSSCTestCase):
             }
         ]
         with TempDirectory() as temp_dir:
-            with self.assertRaisesRegex(ValueError,
-                                        'username and password are required for maven_servers.'):
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"Configuration for maven servers must specify both "
+                r"'username' and 'password' or neither: {'id': 'one', 'password': 'password1'}"
+            ):
                 generate_maven_settings(temp_dir.path, maven_servers, None, None)
 
     def test_generate_maven_repositories_exists(self):
@@ -66,7 +75,7 @@ class TestMavenUtils(BaseTSSCTestCase):
             generate_maven_settings(temp_dir.path, None, maven_repositories, None)
             with open(temp_dir.path + '/settings.xml', 'r') as tester:
                 results = tester.read()
-                assert results == settings
+                self.assertEquals(results, settings)
 
     def test_generate_maven_repositories_id_does_not_exists(self):
         maven_repositories = [
@@ -77,8 +86,11 @@ class TestMavenUtils(BaseTSSCTestCase):
             }
         ]
         with TempDirectory() as temp_dir:
-            with self.assertRaisesRegex(ValueError,
-                                        'id and url are required for maven_repositories.'):
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"Configuration for maven repository must specify a 'id':"
+                r" {'url': 'repo_url1', 'releases': 'true', 'snapshots': 'true'}"
+            ):
                 generate_maven_settings(temp_dir.path, None, maven_repositories, None)
 
     def test_generate_maven_mirrors_exists(self):
@@ -96,7 +108,7 @@ class TestMavenUtils(BaseTSSCTestCase):
             generate_maven_settings(temp_dir.path, None, None, maven_mirrors)
             with open(temp_dir.path + '/settings.xml', 'r') as tester:
                 results = tester.read()
-                assert results == settings
+                self.assertEquals(results, settings)
 
     def test_generate_maven_mirrors_exists_id_does_not_exists(self):
         maven_mirrors = [
@@ -106,8 +118,11 @@ class TestMavenUtils(BaseTSSCTestCase):
             }
         ]
         with TempDirectory() as temp_dir:
-            with self.assertRaisesRegex(ValueError,
-                                        'id, url and mirrorOf are required for maven_mirrors.'):
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"Configuration for maven mirror must specify a 'id':"
+                r" {'url': 'mirror_url1', 'mirror-of': 'false'}"
+            ):
                 generate_maven_settings(temp_dir.path, None, None, maven_mirrors)
 
     def test_generate_maven_params_empty(self):
@@ -117,7 +132,7 @@ class TestMavenUtils(BaseTSSCTestCase):
             generate_maven_settings(temp_dir.path, None, None, None)
             with open(temp_dir.path + '/settings.xml', 'r') as tester:
                 results = tester.read()
-                assert results == settings
+                self.assertEquals(results, settings)
 
     def test_generate_maven_mirrors_empty(self):
         settings = '<settings />'
@@ -126,4 +141,825 @@ class TestMavenUtils(BaseTSSCTestCase):
             generate_maven_settings(temp_dir.path, None, None, None)
             with open(temp_dir.path + '/settings.xml', 'r') as tester:
                 results = tester.read()
-                assert results == settings
+                self.assertEquals(results, settings)
+
+    def test_add_maven_server_no_user_no_pass(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+        servers_element = ET.Element('servers')
+        root_element.append(servers_element)
+
+        add_maven_server(
+            parent_element=servers_element,
+            maven_server_id='foo'
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers><server><id>foo</id></server></servers></settings>'
+        )
+
+    def test_add_maven_server_user_and_pass(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+        servers_element = ET.Element('servers')
+        root_element.append(servers_element)
+
+        add_maven_server(
+            parent_element=servers_element,
+            maven_server_id='foo',
+            maven_server_username='test-user',
+            maven_server_password='test-pass'
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers><server><id>foo</id>'
+            '<username>test-user</username>'
+            '<password>test-pass</password>'
+            '</server></servers></settings>'
+        )
+
+    def test_add_maven_server_yes_user_no_pass(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+        servers_element = ET.Element('servers')
+        root_element.append(servers_element)
+
+        add_maven_server(
+            parent_element=servers_element,
+            maven_server_id='foo',
+            maven_server_username='test-user'
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers><server><id>foo</id></server></servers></settings>'
+        )
+
+    def test_add_maven_server_no_user_yes_pass(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+        servers_element = ET.Element('servers')
+        root_element.append(servers_element)
+
+        add_maven_server(
+            parent_element=servers_element,
+            maven_server_id='foo',
+            maven_server_password='test-pass'
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers><server><id>foo</id></server></servers></settings>'
+        )
+
+    def test_add_maven_servers_list(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+
+        maven_servers = [
+            {
+                'id': 'id1'
+            },
+            {
+                'id': 'id1',
+                'username': 'username1',
+                'password': 'password1'
+            }
+        ]
+
+        add_maven_servers(
+            parent_element=root_element,
+            maven_servers=maven_servers
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers>'
+            '<server><id>id1</id></server>'
+            '<server><id>id1</id><username>username1</username><password>password1</password></server>'
+            '</servers></settings>'
+        )
+
+    def test_add_maven_servers_dict_no_ids(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+
+        maven_servers = {
+            'id-from-key-1': {
+                'username': 'username1',
+                'password': 'password1'
+            },
+            'id-from-key-2': {
+                'username': 'username2',
+                'password': 'password2'
+            }
+        }
+
+        add_maven_servers(
+            parent_element=root_element,
+            maven_servers=maven_servers
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers>'
+            '<server><id>id-from-key-1</id><username>username1</username><password>password1</password></server>'
+            '<server><id>id-from-key-2</id><username>username2</username><password>password2</password></server>'
+            '</servers></settings>'
+        )
+
+    def test_add_maven_servers_dict_with_ids(self):
+        root_element = ET.Element('settings')
+        tree = ET.ElementTree(root_element)
+
+        maven_servers = {
+            'id-from-key-1': {
+                'username': 'username1',
+                'password': 'password1'
+            },
+            'id-from-key-2': {
+                'id': 'override-id-2',
+                'username': 'username2',
+                'password': 'password2'
+            }
+        }
+
+        add_maven_servers(
+            parent_element=root_element,
+            maven_servers=maven_servers
+        )
+
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            '<settings><servers>'
+            '<server><id>id-from-key-1</id><username>username1</username><password>password1</password></server>'
+            '<server><id>override-id-2</id><username>username2</username><password>password2</password></server>'
+            '</servers></settings>'
+        )
+
+    def test_add_maven_servers_list_missing_pass(self):
+        root_element = ET.Element('settings')
+
+        maven_servers = [
+            {
+                'id': 'invalid',
+                'username': 'username1',
+            },
+            {
+                'id': 'valid',
+                'username': 'username1',
+                'password': 'password1'
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven servers must specify both 'username' and 'password'"
+            r" or neither: {'id': 'invalid', 'username': 'username1'}"
+        ):
+            add_maven_servers(
+                parent_element=root_element,
+                maven_servers=maven_servers
+            )
+
+    def test_add_maven_servers_list_missing_username(self):
+        root_element = ET.Element('settings')
+
+        maven_servers = [
+            {
+                'id': 'invalid',
+                'password': 'password1'
+            },
+            {
+                'id': 'valid',
+                'username': 'username1',
+                'password': 'password1'
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven servers must specify both 'username' and 'password'"
+            r" or neither: {'id': 'invalid', 'password': 'password1'}"
+        ):
+            add_maven_servers(
+                parent_element=root_element,
+                maven_servers=maven_servers
+            )
+    def test_add_maven_servers_dict_missing_pass(self):
+        root_element = ET.Element('settings')
+
+        maven_servers = {
+            'invalid': {
+                'username': 'username1',
+            },
+            'valid': {
+                'username': 'username1',
+                'password': 'password1'
+            }
+        }
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven server \(invalid\) must specify"
+            r" both 'username' and 'password' or neither: {'username': 'username1'}"
+        ):
+            add_maven_servers(
+                parent_element=root_element,
+                maven_servers=maven_servers
+            )
+
+    def test_add_maven_servers_dict_missing_username(self):
+        root_element = ET.Element('settings')
+
+        maven_servers = {
+            'invalid': {
+                'password': 'password1'
+            },
+            'valid': {
+                'username': 'username1',
+                'password': 'password1'
+            }
+        }
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven server \(invalid\) must specify"
+            r" both 'username' and 'password' or neither: {'password': 'password1'}"
+        ):
+            add_maven_servers(
+                parent_element=root_element,
+                maven_servers=maven_servers
+            )
+
+    def test_add_maven_repository_no_release_no_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url'
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_false_release_no_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            releases_enabled=False
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url><releases><enabled>False</enabled></releases></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_true_release_no_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            releases_enabled=True
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url><releases><enabled>True</enabled></releases></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_no_release_false_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            snapshots_enabled=False
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url><snapshots><enabled>False</enabled></snapshots></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_no_release_true_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            snapshots_enabled=True
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url><snapshots><enabled>True</enabled></snapshots></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_False_release_true_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            releases_enabled=False,
+            snapshots_enabled=True
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url>"
+            r"<releases><enabled>False</enabled></releases>"
+            r"<snapshots><enabled>True</enabled></snapshots></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_repository_true_release_true_snapshot(self):
+        root_element = ET.Element('settings')
+        profiles_element = ET.Element('profiles')
+        root_element.append(profiles_element)
+        profile_element = ET.Element('profile')
+        profiles_element.append(profile_element)
+        repositories_element = ET.Element('repositories')
+        profile_element.append(repositories_element)
+
+        add_maven_repository(
+            parent_element=repositories_element,
+            repository_id='test-id-1',
+            repository_url='test-url',
+            releases_enabled=True,
+            snapshots_enabled=True
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles>"
+            r"<profile><repositories>"
+            r"<repository><id>test-id-1</id><url>test-url</url>"
+            r"<releases><enabled>True</enabled></releases>"
+            r"<snapshots><enabled>True</enabled></snapshots></repository>"
+            r"</repositories></profile>"
+            r"</profiles></settings>"
+        )
+
+    def test_add_maven_servers_list(self):
+        root_element = ET.Element('settings')
+
+        maven_repositories = [
+            {
+                'id': 'server-id-1',
+                'url': 'url-1'
+            },
+            {
+                'id': 'server-id-2',
+                'url': 'url-2'
+            }
+        ]
+
+        add_maven_repositories(
+            parent_element=root_element,
+            maven_repositories=maven_repositories
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles><profile><repositories>"
+            r"<repository><id>server-id-1</id><url>url-1</url></repository>"
+            r"<repository><id>server-id-2</id><url>url-2</url></repository>"
+            r"</repositories></profile></profiles></settings>"
+        )
+
+    def test_add_maven_servers_dict_with_id_elements(self):
+        root_element = ET.Element('settings')
+
+        maven_repositories = {
+            'ignore-me-1': {
+                'id': 'server-id-1',
+                'url': 'url-1'
+            },
+            'ingnore-me-2': {
+                'id': 'server-id-2',
+                'url': 'url-2'
+            }
+        }
+
+        add_maven_repositories(
+            parent_element=root_element,
+            maven_repositories=maven_repositories
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles><profile><repositories>"
+            r"<repository><id>server-id-1</id><url>url-1</url></repository>"
+            r"<repository><id>server-id-2</id><url>url-2</url></repository>"
+            r"</repositories></profile></profiles></settings>"
+        )
+
+    def test_add_maven_servers_dict_no_id_elements(self):
+        root_element = ET.Element('settings')
+
+        maven_repositories = {
+            'use-me-1': {
+                'url': 'url-1'
+            },
+            'ingnore-me-2': {
+                'id': 'server-id-2',
+                'url': 'url-2'
+            }
+        }
+
+        add_maven_repositories(
+            parent_element=root_element,
+            maven_repositories=maven_repositories
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><profiles><profile><repositories>"
+            r"<repository><id>use-me-1</id><url>url-1</url></repository>"
+            r"<repository><id>server-id-2</id><url>url-2</url></repository>"
+            r"</repositories></profile></profiles></settings>"
+        )
+
+    def test_add_maven_mirror_valid(self):
+        root_element = ET.Element('settings')
+        mirrors_element = ET.Element('mirrors')
+        root_element.append(mirrors_element)
+
+        add_maven_mirror(
+            parent_element=mirrors_element,
+            maven_mirror_id='test-id-1',
+            maven_mirror_url='test-url-1',
+            maven_mirror_mirror_of='test-mirror-of-1'
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><mirrors>"
+            r"<mirror>"
+            r"<id>test-id-1</id>"
+            r"<url>test-url-1</url>"
+            r"<mirrorOf>test-mirror-of-1</mirrorOf>"
+            r"</mirror>"
+            r"</mirrors></settings>"
+        )
+
+    def test_add_maven_mirrors_list_valid(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = [
+            {
+                'id': 'test-id-1',
+                'url': 'test-url-1',
+                'mirror-of': 'test-mirror-of-1'
+            },
+            {
+                'id': 'test-id-2',
+                'url': 'test-url-2',
+                'mirror-of': 'test-mirror-of-2'
+            }
+        ]
+
+        add_maven_mirrors(
+            parent_element=root_element,
+            maven_mirrors=maven_mirrors
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><mirrors>"
+            r"<mirror>"
+            r"<id>test-id-1</id>"
+            r"<url>test-url-1</url>"
+            r"<mirrorOf>test-mirror-of-1</mirrorOf>"
+            r"</mirror>"
+            r"<mirror>"
+            r"<id>test-id-2</id>"
+            r"<url>test-url-2</url>"
+            r"<mirrorOf>test-mirror-of-2</mirrorOf>"
+            r"</mirror>"
+            r"</mirrors></settings>"
+        )
+
+    def test_add_maven_mirrors_dict_with_ids(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = {
+            'ignore-me-1': {
+                'id': 'test-id-1',
+                'url': 'test-url-1',
+                'mirror-of': 'test-mirror-of-1'
+            },
+            'ignore-me-2': {
+                'id': 'test-id-2',
+                'url': 'test-url-2',
+                'mirror-of': 'test-mirror-of-2'
+            }
+        }
+
+        add_maven_mirrors(
+            parent_element=root_element,
+            maven_mirrors=maven_mirrors
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><mirrors>"
+            r"<mirror>"
+            r"<id>test-id-1</id>"
+            r"<url>test-url-1</url>"
+            r"<mirrorOf>test-mirror-of-1</mirrorOf>"
+            r"</mirror>"
+            r"<mirror>"
+            r"<id>test-id-2</id>"
+            r"<url>test-url-2</url>"
+            r"<mirrorOf>test-mirror-of-2</mirrorOf>"
+            r"</mirror>"
+            r"</mirrors></settings>"
+        )
+
+    def test_add_maven_mirrors_dict_without_id(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = {
+            'use-me-1': {
+                'url': 'test-url-1',
+                'mirror-of': 'test-mirror-of-1'
+            },
+            'ignore-me-2': {
+                'id': 'test-id-2',
+                'url': 'test-url-2',
+                'mirror-of': 'test-mirror-of-2'
+            }
+        }
+
+        add_maven_mirrors(
+            parent_element=root_element,
+            maven_mirrors=maven_mirrors
+        )
+
+        tree = ET.ElementTree(root_element)
+        tree_write_out = BytesIO()
+        tree.write(tree_write_out)
+
+        self.assertEqual(
+            tree_write_out.getvalue().decode(),
+            r"<settings><mirrors>"
+            r"<mirror>"
+            r"<id>use-me-1</id>"
+            r"<url>test-url-1</url>"
+            r"<mirrorOf>test-mirror-of-1</mirrorOf>"
+            r"</mirror>"
+            r"<mirror>"
+            r"<id>test-id-2</id>"
+            r"<url>test-url-2</url>"
+            r"<mirrorOf>test-mirror-of-2</mirrorOf>"
+            r"</mirror>"
+            r"</mirrors></settings>"
+        )
+
+    def test_add_maven_mirrors_list_missing_id(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = [
+            {
+                'url': 'test-url-1',
+                'mirror-of': 'test-mirror-of-1'
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven mirror must specify a 'id':"
+            r" {'url': 'test-url-1', 'mirror-of': 'test-mirror-of-1'}"
+        ):
+            add_maven_mirrors(
+                parent_element=root_element,
+                maven_mirrors=maven_mirrors
+            )
+
+    def test_add_maven_mirrors_list_missing_url(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = [
+            {
+                'id': 'test-id-1',
+                'mirror-of': 'test-mirror-of-1'
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven mirror must specify a 'url':"
+            r" {'id': 'test-id-1', 'mirror-of': 'test-mirror-of-1'}"
+        ):
+            add_maven_mirrors(
+                parent_element=root_element,
+                maven_mirrors=maven_mirrors
+            )
+
+    def test_add_maven_mirrors_list_missing_mirror_of(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = [
+            {
+                'id': 'test-id-1',
+                'url': 'test-url-1'
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven mirror must specify"
+            r" a 'mirror-of': {'id': 'test-id-1', 'url': 'test-url-1'}"
+        ):
+            add_maven_mirrors(
+                parent_element=root_element,
+                maven_mirrors=maven_mirrors
+            )
+
+    def test_add_maven_mirrors_dict_missing_url(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = {
+            'ignore-me-1': {
+                'id': 'test-id-1',
+                'mirror-of': 'test-mirror-of-1'
+            }
+        }
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven mirror \(ignore-me-1\) must specify a 'url':"
+            r" {'id': 'test-id-1', 'mirror-of': 'test-mirror-of-1'}"
+        ):
+            add_maven_mirrors(
+                parent_element=root_element,
+                maven_mirrors=maven_mirrors
+            )
+
+    def test_add_maven_mirrors_dict_missing_mirror_of(self):
+        root_element = ET.Element('settings')
+
+        maven_mirrors = {
+            'ignore-me-1': {
+                'id': 'test-id-1',
+                'url': 'test-url-1'
+            }
+        }
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Configuration for maven mirror \(ignore-me-1\) must specify a 'mirror-of':"
+            r" {'id': 'test-id-1', 'url': 'test-url-1'}"
+        ):
+            add_maven_mirrors(
+                parent_element=root_element,
+                maven_mirrors=maven_mirrors
+            )

--- a/tssc/__init__.py
+++ b/tssc/__init__.py
@@ -154,25 +154,41 @@ From least precedence to highest precedence.
 
         # Optional.
         # Maven server settings for settings.xml file
-        maven-servers:
-        -  id: ''
-           username: ''
-           password: ''
+        #maven-servers:
+        #  internal-mirror-1:
+        #    id: ''
+        #    username: ''
+        #    password: ''
+        #  internal-mirror-2:
+        #    id: ''
+        #    username: ''
+        #    password: ''
 
         # Optional.
         # Maven repository settings for settings.xml file
-        maven-repositories:
-        - id: ''
-          url: ''
-          snapshots: ''
-          releases: ''
+        #maven-repositories:
+        #  internal-mirror-1:
+        #    id: ''
+        #    url: ''
+        #    snapshots: ''
+        #    releases: ''
+        #  internal-mirror-2:
+        #    id: ''
+        #    url: ''
+        #    snapshots: ''
+        #    releases: ''
 
         # Optional.
         # Maven mirror settings for settings.xml file
-        maven-mirrors:
-        - id: ''
-          url: ''
-          mirror-of: ''
+        #maven-mirrors:
+        #  internal-mirror-1:
+        #    id: ''
+        #    url: ''
+        #    mirror-of: ''
+        #  internal-mirror-2:
+        #    id: ''
+        #    url: ''
+        #    mirror-of: ''
 
         # Dictionary of container registries to authenticate with.
         # Suggest putting in global configuration so it can be used for creating and pushing

--- a/tssc/step_implementers/push_artifacts/maven.py
+++ b/tssc/step_implementers/push_artifacts/maven.py
@@ -96,11 +96,10 @@ Example: Results
 
 """
 import sys
-import sh
 
+import sh
 from tssc import StepImplementer
 from tssc.config import ConfigValue
-
 from tssc.utils.maven import generate_maven_settings
 
 DEFAULT_CONFIG = {}
@@ -216,7 +215,8 @@ class Maven(StepImplementer):
                     '-DrepositoryId=' + maven_push_artifact_repo_id,
                     '-s' + settings_file,
                     _out=sys.stdout,
-                    _err=sys.stderr
+                    _err=sys.stderr,
+                    _tee='err'
                 )
             except sh.ErrorReturnCode as error:
                 raise RuntimeError(f'Error invoking mvn: {error}') from error

--- a/tssc/step_implementers/tag_source/git.py
+++ b/tssc/step_implementers/tag_source/git.py
@@ -52,11 +52,12 @@ Results output by this step.
         }
     }
 """
-from io import StringIO
 import re
 import sys
+from io import StringIO
+
 import sh
-from tssc import StepImplementer, DefaultSteps
+from tssc import DefaultSteps, StepImplementer
 
 DEFAULT_CONFIG = {}
 
@@ -197,10 +198,11 @@ class Git(StepImplementer):
                 sh.git.config(
                     '--get',
                     'remote.origin.url',
-                    _out=out,
-                    _tee=True,
                     _encoding='UTF-8',
-                    _decode_errors='ignore'
+                    _decode_errors='ignore',
+                    _out=out,
+                    _err=sys.stderr,
+                    _tee='err'
                 )
                 git_url = out.getvalue().rstrip()
 
@@ -231,10 +233,11 @@ class Git(StepImplementer):
                 git_tag_value,
                 '-f',
                 _out=sys.stdout,
-                _err=sys.stderr
+                _err=sys.stderr,
+                _tee='err'
             )
         except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
-            raise RuntimeError('Error invoking git tag ' + git_tag_value) from error
+            raise RuntimeError(f"Error pushing git tag ({git_tag_value}): {error}") from error
 
     @staticmethod
     def _git_push(url=None):  # pragma: no cover
@@ -244,13 +247,15 @@ class Git(StepImplementer):
                     url,
                     '--tag',
                     _out=sys.stdout,
-                    _err=sys.stderr
+                    _err=sys.stderr,
+                    _tee='err'
                 )
             else:
                 sh.git.push(
                     '--tag',
                     _out=sys.stdout,
-                    _err=sys.stderr
+                    _err=sys.stderr,
+                    _tee='err'
                 )
         except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
             raise RuntimeError('Error invoking git push') from error

--- a/tssc/utils/io.py
+++ b/tssc/utils/io.py
@@ -5,10 +5,47 @@ import io
 import random
 import re
 
+def create_sh_redirect_to_multiple_streams_fn_callback(streams):
+    """Creates and returns a function callback that will write given data to multiple given streams.
+
+    AKA: this essentially allows you to do 'tee' for sh commands.
+
+    Parameters
+    ----------
+    streams : list of io.IOBase
+        Streams to write to.
+
+    Examples
+    --------
+    Will write output directed at stdout to stdout and a results file and output directed
+    at stderr to stderr and a results file.
+    >>> with open('/tmp/results_file', 'w') as results_file:
+    ...     out_callback = create_sh_redirect_to_multiple_streams_fn_callback([
+    ...         sys.stdout,
+    ...         results_file
+    ...     ])
+    ...     err_callback = create_sh_redirect_to_multiple_streams_fn_callback([
+    ...         sys.stderr,
+    ...         results_file
+    ...     ])
+    ...     sh.echo('hello world')
+    hello world
+
+    Returns
+    -------
+    function(data)
+        Function that takes one parameter, data, and writes that value to all the given streams.
+    """
+    def sh_redirect_to_multiple_streams(data):
+        for stream in streams:
+            stream.write(data)
+
+    return sh_redirect_to_multiple_streams
+
 class TextIOSelectiveObfuscator(io.TextIOBase):
     """Extends the base class for text streams to allow the obfuscation of given patterns.
 
-    This is useful to prevent accidently writing "sensitive" information to stdout/stderr.
+    This is useful to prevent accidentally writing "sensitive" information to stdout/stderr.
 
     Parameters
     ----------

--- a/tssc/utils/maven.py
+++ b/tssc/utils/maven.py
@@ -29,9 +29,9 @@ def generate_maven_settings(working_dir, maven_servers, maven_repositories, mave
     """
 
     root = ET.Element('settings')
-    generate_maven_servers(root, maven_servers)
-    generate_maven_repositories(root, maven_repositories)
-    generate_maven_mirrors(root, maven_mirrors)
+    add_maven_servers(root, maven_servers)
+    add_maven_repositories(root, maven_repositories)
+    add_maven_mirrors(root, maven_mirrors)
 
     tree = ET.ElementTree(root)
 
@@ -41,110 +41,350 @@ def generate_maven_settings(working_dir, maven_servers, maven_repositories, mave
 
     return settings_path
 
-def generate_maven_servers(ElementTree, maven_servers): # pylint: disable=invalid-name
-    """
-    Generates maven servers section of settings.xml and appends to the file
+def add_maven_servers(parent_element, maven_servers):
+    """Adds <servers> element to parent element and creates <server> elements for each given
+    maven server.
 
     Parameters
     ----------
-    maven_servers:
-        Dictionary of id, username, password
+    parent_element : ET.Element
+        Parent element to add the <servers> element too.
+
+    maven_servers : (dict, list)
+        List of dicts or dicts of dicts to create <server> elements for.
 
     Raises
     ------
-    ValueError
-        If required fields are not provided a value.
+    AssertionError
+        * if username given without password or password without username
+        * if no id given
     """
 
-    if maven_servers is not None:
-        servers = ET.Element('servers')
-        ElementTree.append(servers)
-        for server in maven_servers:
-            if server.get('id'):
-                server_element = ET.Element('server')
-                servers.append(server_element)
-                server_id = ET.SubElement(server_element, 'id')
-                server_id.text = server['id']
-                if server.get('username') and server.get('password'):
-                    server_username = ET.SubElement(server_element, 'username')
-                    server_username.text = server['username']
-                    server_password = ET.SubElement(server_element, 'password')
-                    server_password.text = server['password']
-                else:
-                    if server.get('username') or server.get('password'):
-                        raise ValueError('username and password are required for maven_servers.')
+    if maven_servers is None:
+        return
+
+    assert isinstance(maven_servers, (dict, list))
+
+    servers_element = ET.Element('servers')
+    parent_element.append(servers_element)
+
+    if isinstance(maven_servers, dict):
+        for maven_server_key, maven_server_conf in maven_servers.items():
+            assert \
+                ( \
+                    ('username' in maven_server_conf) \
+                    and \
+                    ('password' in maven_server_conf) \
+                ) \
+                or \
+                ( \
+                    ('username' not in maven_server_conf) \
+                    and \
+                    ('password' not in maven_server_conf) \
+                ), \
+                f"Configuration for maven server ({maven_server_key})" \
+                f" must specify both 'username' and 'password' or neither: {maven_server_conf}"
+
+            # if id is key in the dict then use that for the maven server id
+            # else use the dict key for the maven server conf as the maven server id
+            if 'id' in maven_server_conf:
+                maven_server_id = maven_server_conf['id']
             else:
-                raise ValueError('id is required for maven_servers.')
+                maven_server_id = maven_server_key
 
-def generate_maven_repositories(ElementTree, maven_repositories): # pylint: disable=invalid-name
-    """
-    Generates maven repositories section of settings.xml and appends to the file
+            add_maven_server(
+                parent_element=servers_element,
+                maven_server_id=maven_server_id,
+                maven_server_username=maven_server_conf.get('username'),
+                maven_server_password=maven_server_conf.get('password')
+            )
+    elif isinstance(maven_servers, list):
+        for maven_server_conf in maven_servers:
+            assert 'id' in maven_server_conf, \
+                "Configuration for maven servers" \
+                f" must specify a 'id': {maven_server_conf}"
+
+            assert \
+                ( \
+                    ('username' in maven_server_conf) \
+                    and \
+                    ('password' in maven_server_conf) \
+                ) \
+                or \
+                ( \
+                    ('username' not in maven_server_conf) \
+                    and \
+                    ('password' not in maven_server_conf) \
+                ), \
+                "Configuration for maven servers" \
+                f" must specify both 'username' and 'password' or neither: {maven_server_conf}"
+
+            maven_server_id = maven_server_conf['id']
+
+            add_maven_server(
+                parent_element=servers_element,
+                maven_server_id=maven_server_id,
+                maven_server_username=maven_server_conf.get('username'),
+                maven_server_password=maven_server_conf.get('password')
+            )
+
+def add_maven_server(
+    parent_element,
+    maven_server_id,
+    maven_server_username=None,
+    maven_server_password=None
+):
+    """Adds a <server> element to the given parent element.
 
     Parameters
     ----------
-    maven_repositories:
-        Dictionary of id, username, password
+    parent_element : ET.Element
+        The parent element to append the new server too.
 
-    Raises
-    ------
-    ValueError
-        If required fields are not provided a value.
+    maven_server_id : str
+        ID of the maven server to add.
+
+    maven_server_username : str, optional
+        Username for the maven server to add.
+        Only used if maven_server_password also provided.
+
+    maven_server_password : str, optional
+        Password for the maven server to add.
+        Only used if maven_server_username is provided.
     """
+    server_element = ET.Element('server')
+    parent_element.append(server_element)
+    server_id = ET.SubElement(server_element, 'id')
+    server_id.text = maven_server_id
+    if maven_server_username and maven_server_password:
+        server_username = ET.SubElement(server_element, 'username')
+        server_username.text = maven_server_username
+        server_password = ET.SubElement(server_element, 'password')
+        server_password.text = maven_server_password
 
-    if maven_repositories is not None:
-        profiles = ET.Element('profiles')
-        ElementTree.append (profiles)
-        profile = ET.Element('profile')
-        profiles.append (profile)
-        repositories = ET.Element('repositories')
-        profile.append(repositories)
-
-        for repository in maven_repositories:
-            if repository.get('id') and repository.get('url'):
-                repository_element = ET.Element('repository')
-                repositories.append(repository_element)
-                repository_id = ET.SubElement(repository_element, 'id')
-                repository_id.text = repository['id']
-                repository_url = ET.SubElement(repository_element, 'url')
-                repository_url.text = repository['url']
-                if repository.get('releases'):
-                    repository_releases = ET.SubElement(repository_element, 'releases')
-                    repository_releases_enabled = ET.SubElement(repository_releases, 'enabled')
-                    repository_releases_enabled.text = repository['releases']
-                if repository.get('snapshots'):
-                    repository_snapshots = ET.SubElement(repository_element, 'snapshots')
-                    repository_snapshots_enabled = ET.SubElement(repository_snapshots, 'enabled')
-                    repository_snapshots_enabled.text = repository['snapshots']
-            else:
-                raise ValueError('id and url are required for maven_repositories.')
-
-def generate_maven_mirrors(ElementTree, maven_mirrors): # pylint: disable=invalid-name
-    """
-    Generates maven mirrors section of settings.xml and appends to the file
+def add_maven_repositories(parent_element, maven_repositories): # pylint: disable=invalid-name
+    """Adds <repositories> element to parent element and child <repository> element for each
+    given maven repository.
 
     Parameters
     ----------
-    maven_mirrors:
-        Dictionary of id, username, password
+    parent_element : ET.Element
+        Parent element to add the <repositories> element to.
+
+    maven_repositories : (dict, list)
+        List of dicts or dicts of dicts to create <repository> elements for.
 
     Raises
     ------
-    ValueError
-        If required fields are not provided a value.
+    AssertionError
+        * id not specified
+        * url not specified
     """
 
-    if maven_mirrors is not None:
-        mirrors = ET.Element('mirrors')
-        ElementTree.append(mirrors)
-        for mirror in maven_mirrors:
-            if mirror.get('id') and mirror.get('url') and mirror.get('mirror-of'):
-                mirror_element = ET.Element('mirror')
-                mirrors.append(mirror_element)
-                mirror_id = ET.SubElement(mirror_element, 'id')
-                mirror_id.text = mirror['id']
-                mirror_url = ET.SubElement(mirror_element, 'url')
-                mirror_url.text = mirror['url']
-                mirror_mirror_of = ET.SubElement(mirror_element, 'mirrorOf')
-                mirror_mirror_of.text = mirror['mirror-of']
+    if maven_repositories is None:
+        return
+
+    assert isinstance(maven_repositories, (dict, list))
+
+    profiles_element = ET.Element('profiles')
+    parent_element.append(profiles_element)
+    profile_element = ET.Element('profile')
+    profiles_element.append(profile_element)
+    repositories_element = ET.Element('repositories')
+    profile_element.append(repositories_element)
+
+    if isinstance(maven_repositories, dict):
+        for maven_repository_key, maven_repository_conf in maven_repositories.items():
+            assert 'url' in maven_repository_conf, \
+                f"Configuration for maven repository ({maven_repository_key})" \
+                f" must specify a 'url': {maven_repository_conf}"
+
+            # if id is key in the dict then use that for the maven repository id
+            # else use the dict key for the maven server conf as the maven server id
+            if 'id' in maven_repository_conf:
+                repository_id = maven_repository_conf['id']
             else:
-                raise ValueError('id, url and mirrorOf are required for maven_mirrors.')
+                repository_id = maven_repository_key
+
+            repository_url = maven_repository_conf['url']
+            releases_enabled = maven_repository_conf.get('releases')
+            snapshots_enabled = maven_repository_conf.get('snapshots')
+
+            add_maven_repository(
+                parent_element=repositories_element,
+                repository_id=repository_id,
+                repository_url=repository_url,
+                releases_enabled=releases_enabled,
+                snapshots_enabled=snapshots_enabled
+            )
+    elif isinstance(maven_repositories, list):
+        for maven_repository_conf in maven_repositories:
+            assert 'id' in maven_repository_conf, \
+                "Configuration for maven repository" \
+                f" must specify a 'id': {maven_repository_conf}"
+
+            assert 'url' in maven_repository_conf, \
+                "Configuration for maven repository" \
+                f" must specify a 'url': {maven_repository_conf}"
+
+            repository_id = maven_repository_conf['id']
+            repository_url = maven_repository_conf['url']
+            releases_enabled = maven_repository_conf.get('releases')
+            snapshots_enabled = maven_repository_conf.get('snapshots')
+
+            add_maven_repository(
+                parent_element=repositories_element,
+                repository_id=repository_id,
+                repository_url=repository_url,
+                releases_enabled=releases_enabled,
+                snapshots_enabled=snapshots_enabled
+            )
+
+def add_maven_repository(
+    parent_element,
+    repository_id,
+    repository_url,
+    releases_enabled=None,
+    snapshots_enabled=None
+):
+    """Add a <repository> element to the given parent element
+
+    Parameters
+    ----------
+    parent_element : ET.Element
+        Parent elemtnt to add the <repository> element to.
+
+    repository_id : str
+        Value for the <id> element
+
+    repository_url : str
+        Value for the <url> element
+
+    releases_enabled : (str, bool), optional
+        Value for <releases><enabled>{snapshots_enabled}</enabled></releases>
+
+    snapshots_enabled : (str, bool), optional
+        Value for <snapshots><enabled>{snapshots_enabled}</enabled></snapshots>
+
+    """
+    repository_element = ET.Element('repository')
+    parent_element.append(repository_element)
+
+    repository_id_element = ET.SubElement(repository_element, 'id')
+    repository_id_element.text = repository_id
+
+    repository_url_element = ET.SubElement(repository_element, 'url')
+    repository_url_element.text = repository_url
+
+    if releases_enabled is not None:
+        repository_releases = ET.SubElement(repository_element, 'releases')
+        repository_releases_enabled = ET.SubElement(repository_releases, 'enabled')
+        repository_releases_enabled.text = str(releases_enabled)
+
+    if snapshots_enabled is not None:
+        repository_snapshots = ET.SubElement(repository_element, 'snapshots')
+        repository_snapshots_enabled = ET.SubElement(repository_snapshots, 'enabled')
+        repository_snapshots_enabled.text = str(snapshots_enabled)
+
+def add_maven_mirrors(parent_element, maven_mirrors):
+    """Add <mirror> element for given maven mirror to <mirrors> element to given parent element.
+
+    Parameters
+    ----------
+    parent_element : ET.Element
+        Parent element to add <mirrors> element to.
+
+    maven_mirrors : (dict, list)
+        List of dicts or dicts of dicts of maven mirror configurations.
+
+    Raises
+    ------
+    AssertionError
+        * if maven mirror id not given
+        * if maven mirror url not given
+        * if maven mirror mirror-of not given
+    """
+
+    if maven_mirrors is None:
+        return
+
+    assert isinstance(maven_mirrors, (dict, list))
+
+    mirrors_element = ET.Element('mirrors')
+    parent_element.append(mirrors_element)
+
+    if isinstance(maven_mirrors, dict):
+        for maven_mirror_key, maven_mirror_conf in maven_mirrors.items():
+            assert 'url' in maven_mirror_conf, \
+                f"Configuration for maven mirror ({maven_mirror_key})" \
+                f" must specify a 'url': {maven_mirror_conf}"
+            assert 'mirror-of' in maven_mirror_conf, \
+                f"Configuration for maven mirror ({maven_mirror_key})" \
+                f" must specify a 'mirror-of': {maven_mirror_conf}"
+
+            # if id is key in the dict then use that for the maven mirror id
+            # else use the dict key for the maven mirror conf as the maven mirror id
+            if 'id' in maven_mirror_conf:
+                maven_mirror_id = maven_mirror_conf['id']
+            else:
+                maven_mirror_id = maven_mirror_key
+
+            add_maven_mirror(
+                parent_element=mirrors_element,
+                maven_mirror_id=maven_mirror_id,
+                maven_mirror_url=maven_mirror_conf['url'],
+                maven_mirror_mirror_of=maven_mirror_conf['mirror-of']
+            )
+    elif isinstance(maven_mirrors, list):
+        for maven_mirror_conf in maven_mirrors:
+            assert 'id' in maven_mirror_conf, \
+                "Configuration for maven mirror" \
+                f" must specify a 'id': {maven_mirror_conf}"
+            assert 'url' in maven_mirror_conf, \
+                "Configuration for maven mirror" \
+                f" must specify a 'url': {maven_mirror_conf}"
+            assert 'mirror-of' in maven_mirror_conf, \
+                "Configuration for maven mirror" \
+                f" must specify a 'mirror-of': {maven_mirror_conf}"
+
+            add_maven_mirror(
+                parent_element=mirrors_element,
+                maven_mirror_id=maven_mirror_conf['id'],
+                maven_mirror_url=maven_mirror_conf['url'],
+                maven_mirror_mirror_of=maven_mirror_conf['mirror-of']
+            )
+
+def add_maven_mirror(
+    parent_element,
+    maven_mirror_id,
+    maven_mirror_url,
+    maven_mirror_mirror_of
+):
+    """Adds a <mirror> element to given parent element.
+
+    Parameters
+    ----------
+    parent_element : ET.Element
+        Parent element to add new <mirror> element to
+
+    maven_mirror_id : str
+        Value for <id> element.
+
+    maven_mirror_url : str
+        Value for <url> element.
+
+    maven_mirror_mirror_of : str
+        Value for <mirrorOf> element.
+
+    """
+    mirror_element = ET.Element('mirror')
+    parent_element.append(mirror_element)
+
+    mirror_id = ET.SubElement(mirror_element, 'id')
+    mirror_id.text = maven_mirror_id
+
+    mirror_url = ET.SubElement(mirror_element, 'url')
+    mirror_url.text = maven_mirror_url
+
+    mirror_mirror_of = ET.SubElement(mirror_element, 'mirrorOf')
+    mirror_mirror_of.text = maven_mirror_mirror_of


### PR DESCRIPTION
# changes
* introduce tests/helpers/base_step_implementer_test_case.py
* introduce tssc.utils.create_sh_redirect_to_multiple_streams_fn_callback (tee for @ppremru )
* tag-source (git) now doesn't lose errors
* better testing of argocd funcitons
* deploy (argocd) now deals with names longer then 63 chars
* validate-envionrment-configuration (config-lint) now always prints the results to stdout as well as file
* push-artifacts (maven) - update to take dict or list for maven-servers, maven-repositories, and maven-mirrors

# integration testing

## tag-source (git)

## bad password
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-6/11/console
```
                            Standard Out - tag-source                            
    --------------------------------------------------------------------------------
        remote: invalid credentials from 10.128.4.61
        fatal: Authentication failed for 'http://sa-********-reference-apps:**********************@gitea.gitea.svc.cluster.local:3000/**********************-references/reference-quarkus-mvn-jenkins.git/'
        Error calling step (tag-source): Error invoking git push
Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/****************/lib64/python3.6/site-packages/************************/step_implementers/tag_source/git.py", line 251, in _git_push
...
```

## deploy (argocd)

### really long name
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-8/1/

## validate config (config-lint)

### success
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-6/
```
 --------------------------------------------------------------------------------
                   Standard Out - validate-environment-configuration                
    --------------------------------------------------------------------------------
        Exclude patterns: []
        Filenames to scan: [/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*************************************-working/deploy/deploy_argocd_manifests.yml]
        Processing /home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/********************************-working/deploy/deploy_argocd_manifests.yml
        Found variables []
        Rule: ID: TSSC_TEST_EXAMPLE_LABEL Message: Deployment example for a label
        filtering rule resources on Resource stringChecking resource sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        Checking Category: , Type: Deployment, Id: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        ResourceID: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev Type: Deployment {true }
        Filenames to scan: [/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*************-working/deploy/deploy_argocd_manifests.yml]
        Processing /home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/************************************-working/deploy/deploy_argocd_manifests.yml
        Found variables []
        Rule: ID: TSSC_TEST_FOR_SERVICE_MESH Message: Check for sidecar service mesh
        filtering rule resources on Resource stringChecking resource sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        Checking Category: , Type: Namespace, Id: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        ResourceID: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev Type: Namespace {false spec.template.metadata.annotations does not contain "sidecar.istio.io/inject": true}
        {
          "FilesScanned": [
            "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*****************************-working/deploy/deploy_argocd_manifests.yml",
            "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*******************-working/deploy/deploy_argocd_manifests.yml"
          ],
          "Violations": [
            {
              "RuleID": "TSSC_TEST_FOR_SERVICE_MESH",
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Namespace",
              "Category": "",
              "Status": "WARNING",
              "RuleMessage": "Check for sidecar service mesh",
              "AssertionMessage": "spec.template.metadata.annotations does not contain \"sidecar.istio.io/inject\": true",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*******************-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0,
              "CreatedAt": "2020-09-29T16:11:05Z"
            }
          ],
          "ResourcesScanned": [
            {
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Deployment",
              "RuleID": "TSSC_TEST_EXAMPLE_LABEL",
              "Status": "OK",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/******************-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0
            },
            {
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Namespace",
              "RuleID": "TSSC_TEST_FOR_SERVICE_MESH",
              "Status": "WARNING",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/************************-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0
            }
          ]
        }
```

### failure
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-6/9/console
```
 --------------------------------------------------------------------------------
                   Standard Out - validate-environment-configuration                
    --------------------------------------------------------------------------------
        Exclude patterns: []
        Filenames to scan: [/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/****************************************-working/deploy/deploy_argocd_manifests.yml]
        Processing /home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/********************************-working/deploy/deploy_argocd_manifests.yml
        Found variables []
        Rule: ID: TSSC_TEST_EXAMPLE_LABEL Message: Deployment example for a label
        filtering rule resources on Resource stringChecking resource sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        Checking Category: , Type: Deployment, Id: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        ResourceID: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev Type: Deployment {false spec.template.metadata.labels.app does not contain foo-bar}
        Filenames to scan: [/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*****-working/deploy/deploy_argocd_manifests.yml]
        Processing /home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/******-working/deploy/deploy_argocd_manifests.yml
        Found variables []
        Rule: ID: TSSC_TEST_FOR_SERVICE_MESH Message: Check for sidecar service mesh
        filtering rule resources on Resource stringChecking resource sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        Checking Category: , Type: Namespace, Id: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev
        ResourceID: sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev Type: Namespace {false spec.template.metadata.annotations does not contain "sidecar.istio.io/inject": true}
        {
          "FilesScanned": [
            "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/**************-working/deploy/deploy_argocd_manifests.yml",
            "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/************-working/deploy/deploy_argocd_manifests.yml"
          ],
          "Violations": [
            {
              "RuleID": "TSSC_TEST_EXAMPLE_LABEL",
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Deployment",
              "Category": "",
              "Status": "FAILURE",
              "RuleMessage": "Deployment example for a label",
              "AssertionMessage": "spec.template.metadata.labels.app does not contain foo-bar",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/*********************************-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0,
              "CreatedAt": "2020-09-29T16:02:43Z"
            },
            {
              "RuleID": "TSSC_TEST_FOR_SERVICE_MESH",
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Namespace",
              "Category": "",
              "Status": "WARNING",
              "RuleMessage": "Check for sidecar service mesh",
              "AssertionMessage": "spec.template.metadata.annotations does not contain \"sidecar.istio.io/inject\": true",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/************-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0,
              "CreatedAt": "2020-09-29T16:02:43Z"
            }
          ],
          "ResourcesScanned": [
            {
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Deployment",
              "RuleID": "TSSC_TEST_EXAMPLE_LABEL",
              "Status": "FAILURE",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/******-working/deploy/deploy_argocd_manifests.yml",
              "LineNumber": 0
            },
            {
              "ResourceID": "sc-team-reference-quarkus-mvn-jenkins-fruit-feature-errors-dev",
              "ResourceType": "Namespace",
              "RuleID": "TSSC_TEST_FOR_SERVICE_MESH",
              "Status": "WARNING",
              "Filename": "/home/jenkins/agent/workspace/ference-quarkus-mvn-jenkins_PR-6/****************-working/deploy/deploy_argocd_manifests.yml",
        Error calling step (validate-environment-configuration): Failed config-lint scan. See standard out and standard error.
      "LineNumber": 0
            }
          ]
        }
```

## push-artifacts (maven)

### list
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-6/12/console

*tssc-config-secret.yml (encrypted with sops)*
```
tssc-config:
    global-defaults:
        maven-servers:
        -   id: ENC[AES256_GCM,data:WMGNrR29W82uzAEtRNly,iv:FFEvjLpuOSeg9NjkMlenR7W+8aB+rMEiWvXel8RFD6s=,tag:MqqHEC+LYviNCai1a5DJJg==,type:str]
            username: ENC[AES256_GCM,data:MJvU+w==,iv:xAVMYHibXWIIKd5xu4wWxPHGksRDF9u4pFW329oRUbs=,tag:+aEu2b92EsiRd4IV6Du6ag==,type:str]
            password: ENC[AES256_GCM,data:4e1JeGJJ5grlt1lKxaQOVkaW,iv:YwxanLTJFiwDOJk9T0Om68zNAC5EAoJ/iesaWEo/fBs=,tag:uts/xAxLl8mUj0xSTdhvmA==,type:str]
```

*tssc-config.yml*
```
---
tssc-config:
  global-defaults:
    maven-mirrors:
    - id: internal-mirror
      url: http://artifactory.apps.tssc.rht-set.com/artifactory/release/
      mirror-of: '*'
  push-artifacts:
  - implementer: Maven
    config:
      maven-push-artifact-repo-id: internal-server
      maven-push-artifact-repo-url: http://artifactory.apps.tssc.rht-set.com/artifactory/tssc
```

### dict
https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-6/13/console

*tssc-config-secret.yml (encrypted with sops)*
```
tssc-config:
    global-defaults:
        maven-servers:
            internal-mirror:
                password: ENC[AES256_GCM,data:NYdwD3xTTMosFgcAdas0rMDT,iv:+RAq6DyV0SoIuZnl4FLs7RffTBXkX1epmimJFrPjd1I=,tag:58KEck9GLmB9pW5KryWXOg==,type:str]
```

*tssc-config.yml*
```
---
tssc-config:
  global-defaults:
    maven-servers:
      internal-mirror:
        id: internal-server
        username: tssc
    maven-mirrors:
      internal-mirror:
        id: internal-mirror
        url: http://artifactory.apps.tssc.rht-set.com/artifactory/release/
        mirror-of: '*'
```