### PR TITLE
NAPSSPO-1046 - tssc-jenkins-library - standerdize on container-image-version, container-image-uri, and container-image-tag

### DIFF
--- a/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
+++ b/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
@@ -55,7 +55,7 @@ class TestStepImplementerContainerImageStaticComplianceScan(BaseTSSCTestCase):
                 bytes(
                     f'''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version:: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   create-container-image:
@@ -365,7 +365,7 @@ class TestStepImplementerContainerImageStaticComplianceScan(BaseTSSCTestCase):
                 bytes(
                     f'''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   create-container-image:
                     image-tar-file: {image_tar_file_path}
                   tag-source:
@@ -433,7 +433,7 @@ class TestStepImplementerContainerImageStaticComplianceScan(BaseTSSCTestCase):
                             'success': True
                         }
                     },
-                    'generate-metadata': {'image-tag': 'not_latest'},
+                    'generate-metadata': {'container-image-version': 'not_latest'},
                     'create-container-image': {'image-tar-file': f'{image_tar_file_path}'},
                     'tag-source': {'tag': 'git_tag'}
                 }

--- a/tests/step_implementers/create_container_image/test_buildah.py
+++ b/tests/step_implementers/create_container_image/test_buildah.py
@@ -165,7 +165,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             expected_step_results = {'tssc-results': {
                 'create-container-image': {
-                    'image-tag': tag,
+                    'container-image-version': tag,
                     'image-tar-file': image_tar_file
                 }
             }}
@@ -210,7 +210,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                     '''tssc-results:
                   generate-metadata:
                     version: {version}
-                    image-tag: {version}
+                    container-image-version: {version}
                 '''.format(version=version),
                     'utf-8')
                 )
@@ -235,11 +235,11 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             expected_step_results = {'tssc-results': {
                 'generate-metadata': {
-                    'image-tag': version,
+                    'container-image-version': version,
                     'version': version
                 },
                 'create-container-image': {
-                    'image-tag': tag,
+                    'container-image-version': tag,
                     'image-tar-file': image_tar_file
                 }
             }}
@@ -299,7 +299,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             expected_step_results = {'tssc-results': {
                 'create-container-image': {
-                    'image-tag': tag,
+                    'container-image-version': tag,
                     'image-tar-file' : image_tar_file
                 }
             }}
@@ -400,7 +400,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             expected_step_results = {'tssc-results': {
                 'create-container-image': {
-                    'image-tag': tag,
+                    'container-image-version': tag,
                     'image-tar-file' : image_tar_file
                 }
             }}
@@ -452,7 +452,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                     '''tssc-results:
                           generate-metadata:
                             version: {version}
-                            image-tag: {version}
+                            container-image-version: {version}
                         '''.format(version=version),
                             'utf-8')
                 )
@@ -477,11 +477,11 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             expected_step_results = {'tssc-results': {
                 'generate-metadata': {
-                    'image-tag': version,
+                    'container-image-version': version,
                     'version': version
                 },
                 'create-container-image': {
-                    'image-tag': tag,
+                    'container-image-version': tag,
                     'image-tar-file' : image_tar_file
                 }
             }}

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -49,14 +49,14 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
-                )
+            )
             temp_dir.write(
                 'values.yaml.j2',
                 bytes(
@@ -96,10 +96,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -187,7 +187,7 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
@@ -232,7 +232,7 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -262,8 +262,9 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
 
             git_mock.side_effect=self.git_rev_parse_side_effect
             with self.assertRaisesRegex(
-                    ValueError,
-                    r"No image url was specified"):
+                AssertionError,
+                r'Can not determine container image repository uri.'
+            ):
                 self.run_step_test_with_result_validation(temp_dir, 'deploy', config, expected_step_results, runtime_args, environment_name)
 
             argocd_mock.login.assert_called_once_with(
@@ -300,7 +301,7 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
@@ -345,7 +346,7 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -371,8 +372,8 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             runtime_args = {
                 'git-username': 'unit_test_username',
                 'git-password': 'unit_test_password',
-                'image-url': image_url,
-                'image-version': image_tag
+                'container-image-uri': image_url,
+                'container-image-version': image_tag
             }
 
             git_mock.side_effect=self.git_rev_parse_side_effect
@@ -419,11 +420,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -466,10 +467,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -537,11 +538,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -584,10 +585,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -683,11 +684,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -730,10 +731,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -810,10 +811,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   push-container-image:
-                    image-url: {image_url}
-                    image-version: {image_tag}
+                    container-image-uri: {image_url}
+                    container-image-version: {image_tag}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -856,11 +857,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url,
-                        'image-version' : image_tag
+                        'container-image-uri' : image_url,
+                        'container-image-version' : image_tag
                     },
                     'deploy': {
                         'result': {
@@ -933,11 +934,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -980,10 +981,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1049,11 +1050,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1097,10 +1098,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1159,11 +1160,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1206,10 +1207,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1272,11 +1273,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1319,10 +1320,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1387,11 +1388,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1434,10 +1435,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1520,11 +1521,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1567,10 +1568,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1645,11 +1646,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1692,10 +1693,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1771,11 +1772,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1818,10 +1819,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -1896,11 +1897,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -1943,10 +1944,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -2016,11 +2017,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -2065,10 +2066,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag
@@ -2142,11 +2143,11 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {image_tag}
+                    container-image-version: {image_tag}
                   tag-source:
                     tag: {git_tag}
                   push-container-image:
-                    image-url: {image_url}
+                    container-image-uri: {image_url}
                 '''.format(image_tag=image_tag, image_url=image_url, git_tag=git_tag),
                     'utf-8')
                 )
@@ -2191,10 +2192,10 @@ class TestStepImplementerDeployArgoCD(BaseStepImplementerTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata' : {
-                        'image-tag' : image_tag
+                        'container-image-version' : image_tag
                     },
                     'push-container-image' : {
-                        'image-url' : image_url
+                        'container-image-uri' : image_url
                     },
                     'tag-source' : {
                         'tag' : git_tag

--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -150,7 +150,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             build = git_branch_last_commit_hash[:7]
             version = "{0}+{1}".format(app_version, build)
             image_tag = "{0}".format(app_version)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': build, 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': build, 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path)})
 
@@ -190,7 +190,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             build = git_branch_last_commit_hash[:7]
             version = "{0}+{1}".format(app_version, build)
             image_tag = "{0}".format(app_version)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': build, 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': build, 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path)})
 
@@ -238,7 +238,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             pre_release = 'feature_test0'
             version = "{0}-{1}+{2}".format(app_version, pre_release, build)
             image_tag = "{0}-{1}".format(app_version, pre_release)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': pre_release, 'build': build, 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': pre_release, 'build': build, 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path)})
 
@@ -280,7 +280,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             build = git_branch_last_commit_hash[:7]
             version = "{0}+{1}".format(app_version, build)
             image_tag = "{0}".format(app_version)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': "42.1", 'pre-release': 'master', 'build': build, 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': "42.1", 'pre-release': 'master', 'build': build, 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path), 'app-version': app_version})
 
@@ -322,7 +322,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             build = "1234"
             version = "{0}+{1}".format(app_version, build)
             image_tag = "{0}".format(app_version)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': git_branch_last_commit_hash[:7], 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'master', 'build': git_branch_last_commit_hash[:7], 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path), 'build': build})
 
@@ -370,6 +370,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseTSSCTestCase):
             pre_release = 'beta1'
             version = "{0}-{1}+{2}".format(app_version, pre_release, build)
             image_tag = "{0}-{1}".format(app_version, pre_release)
-            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'feature_test0', 'build': build, 'version': version, 'image-tag': image_tag}}}
+            expected_step_results = {'tssc-results': {'generate-metadata': {'app-version': app_version, 'pre-release': 'feature_test0', 'build': build, 'version': version, 'container-image-version': image_tag}}}
 
             run_step_test_with_result_validation(temp_dir, 'generate-metadata', config, expected_step_results, runtime_args={'repo-root': str(temp_dir.path), 'pre-release': pre_release})

--- a/tests/step_implementers/push_container_image/test_skopeo.py
+++ b/tests/step_implementers/push_container_image/test_skopeo.py
@@ -30,7 +30,7 @@ class TestStepImplementerPushContainerImageSkopeo(BaseTSSCTestCase):
                     }
                 }
             }
-            expected_step_results = {'tssc-results': {'push-container-image': {'image-tag': ''}}}
+            expected_step_results = {'tssc-results': {'push-container-image': {'container-image-version': ''}}}
 
             with self.assertRaisesRegex(
                 AssertionError,
@@ -82,7 +82,7 @@ class TestStepImplementerPushContainerImageSkopeo(BaseTSSCTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {version}
+                    container-image-version: {version}
                   create-container-image:
                     image-tar-file: {destination}
                 '''.format(version=version, destination=destination),
@@ -113,12 +113,12 @@ class TestStepImplementerPushContainerImageSkopeo(BaseTSSCTestCase):
                         'image-tar-file': destination
                     },
                     'generate-metadata': {
-                        'image-tag': version
+                        'container-image-version': version
                     },
                     'push-container-image': {
-                        'image-tag': "{destination}/{organization}/{application_name}-{service_name}:{version}".format(destination=destination, organization=organization, application_name=application_name, service_name=service_name, version=version),
-                        'image-url': destination,
-                        'image-version' : version
+                        'container-image-uri': f"{destination}/xyzzy/foo-bar",
+                        "container-image-version": version,
+                        'container-image-tag': f"{destination}/xyzzy/foo-bar:1.0-69442c8"
                     }
                 }
             }
@@ -147,7 +147,7 @@ class TestStepImplementerPushContainerImageSkopeo(BaseTSSCTestCase):
                 bytes(
                     '''tssc-results:
                   generate-metadata:
-                    image-tag: {version}
+                    container-image-version: {version}
                   create-container-image:
                     image-tar-file: image.tar
                 '''.format(version=version),
@@ -177,8 +177,8 @@ class TestStepImplementerPushContainerImageSkopeo(BaseTSSCTestCase):
                         'config' : {}
                     }
             }
-            expected_step_results = {'tssc-results': {'create-container-image': {'image-tar-file': 'image.tar'},'generate-metadata': {'image-tag': version},
-                                     'push-container-image': {'image-tag':"docker://{destination}:{version}".format(destination=destination, version=version)}}}
+            expected_step_results = {'tssc-results': {'create-container-image': {'image-tar-file': 'image.tar'},'generate-metadata': {'container-image-version': version},
+                                     'push-container-image': {'container-image-version':"docker://{destination}:{version}".format(destination=destination, version=version)}}}
 
             sh.skopeo.copy.side_effect = sh.ErrorReturnCode('skopeo', b'mock stdout', b'mock error about skopeo runtime')
             with self.assertRaisesRegex(

--- a/tests/step_implementers/tag_source/test_git.py
+++ b/tests/step_implementers/tag_source/test_git.py
@@ -156,7 +156,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
                 version: 1.0+69442c8
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -170,7 +170,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8',
+                        'container-image-version': '1.0-69442c8',
                         'version': '1.0+69442c8'
                     },
                     'tag-source': {
@@ -199,7 +199,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
                 version: 1.0+69442c8
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -215,7 +215,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8',
+                        'container-image-version': '1.0-69442c8',
                         'version': '1.0+69442c8'
                     },
                     'tag-source': {
@@ -243,7 +243,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.makedir('tssc-results')
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -259,7 +259,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8',
+                        'container-image-version': '1.0-69442c8',
                         'version': '1.0+69442c8'
                     },
                     'tag-source': {
@@ -288,7 +288,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.makedir('tssc-results')
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -302,7 +302,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8'
+                        'container-image-version': '1.0-69442c8'
                     },
                     'tag-source': {
                         'tag': '1.0-69442c8'
@@ -327,7 +327,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.makedir('tssc-results')
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -343,7 +343,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8'
+                        'container-image-version': '1.0-69442c8'
                     },
                     'tag-source': {
                         'tag': '1.0-69442c8'
@@ -363,7 +363,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             temp_dir.makedir('tssc-results')
             temp_dir.write('tssc-results/tssc-results.yml', b'''tssc-results:
               generate-metadata:
-                image-tag: 1.0-69442c8
+                container-image-version: 1.0-69442c8
                 ''')
             config = {
                 'tssc-config': {
@@ -379,7 +379,7 @@ class TestStepImplementerTagSourceGit(BaseTSSCTestCase):
             expected_step_results = {
                 'tssc-results': {
                     'generate-metadata': {
-                        'image-tag': '1.0-69442c8'
+                        'container-image-version': '1.0-69442c8'
                     },
                     'tag-source': {
                         'tag': '1.0-69442c8'

--- a/tssc/step_implementers/create_container_image/__init__.py
+++ b/tssc/step_implementers/create_container_image/__init__.py
@@ -16,10 +16,10 @@ Results
 All tssc.StepImplementers for this step should
 minimally produce the following step results.
 
-| Result Key       | Description
-|------------------|------------
-| `image-tag`      | The image ID to tag the built image with when pushing it to a local file
-| `image-tar-file` | Path to the built container image as a tar file
+| Result Key                | Description
+|---------------------------|------------
+| `container-image-version` | Container version to tag built image with
+| `image-tar-file`          | Path to the built container image as a tar file
 
 """
 

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -24,18 +24,17 @@ Results expected from previous steps that this step requires.
 
 | Step Name           | Result Key      | Description
 |---------------------|-----------------|------------
-| `generate-metadata` | `image-tag`     | Version to use when building the image
+| `generate-metadata` | `container-image-version`     | Version to use when building the image
 
 Results
 -------
 
 Results output by this step.
 
-| Result Key       | Description
-|------------------|------------
-| `image-tag`      | The image ID to tag the built image with when pushing it to a local file
-| `image-tar-file` | Path to the built container image as a tar file
-
+| Result Key                | Description
+|---------------------------|------------
+| `container-image-version` | Container version to tag built image with
+| `image-tar-file`          | Path to the built container image as a tar file
 
 ** Example **
 
@@ -148,8 +147,10 @@ class Buildah(StepImplementer):
                              + image_spec_file_location)
 
         if(self.get_step_results(DefaultSteps.GENERATE_METADATA) and \
-          self.get_step_results(DefaultSteps.GENERATE_METADATA).get('image-tag')):
-            image_tag_version = self.get_step_results(DefaultSteps.GENERATE_METADATA)['image-tag']
+          self.get_step_results(DefaultSteps.GENERATE_METADATA).get('container-image-version')):
+            image_tag_version = self.get_step_results(
+                DefaultSteps.GENERATE_METADATA
+            )['container-image-version']
         else:
             image_tag_version = "latest"
             print('No image tag version found in metadata. Using latest')
@@ -223,7 +224,7 @@ class Buildah(StepImplementer):
                 'Issue invoking buildah push to tar file ' + image_tar_file) from error
 
         results = {
-            'image-tag' : tag,
+            'container-image-version' : tag,
             'image-tar-file' : image_tar_file
         }
 

--- a/tssc/step_implementers/deploy/argocd.py
+++ b/tssc/step_implementers/deploy/argocd.py
@@ -68,7 +68,7 @@ Results expected from previous steps that this step may require.
 |------------------------|-----------------|------------
 | `tag-source`           | `tag`           | The git tag to apply to the config repo
 | `push-container-image` | `image-url`     | The image url to use in the deployment
-| `push-container-image` | `image-version` | The image version use in the deployment
+| `push-container-image` | `container-image-version` | The image version use in the deployment
 
 Results
 -------
@@ -430,31 +430,39 @@ users:
 
         return results
 
-    def _get_image_url(self):
-        image_url = None
+    def __get_container_image_repository_uri(self):
+        """Get the container image repository uri.
 
-        if self.get_config_value('image-url'):
-            image_url = self.get_config_value('image-url')
-        else:
-            if(self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE) \
-            and self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE).get('image-url')):
-                image_url = self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE).\
-                            get('image-url')
-            else:
-                print('No image url found in metadata.')
-                raise ValueError('No image url was specified')
-        return image_url
+        Returns
+        -------
+        str
+            Container image repository URI.
+        """
+        push_container_image_results = self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE)
+
+        container_image_repository_uri = self.get_config_value('container-image-uri')
+
+        if container_image_repository_uri is None and push_container_image_results:
+            container_image_repository_uri = push_container_image_results.get(
+                'container-image-uri'
+            )
+
+        assert container_image_repository_uri is not None, \
+            'Can not determine container image repository uri.'
+
+        return container_image_repository_uri
 
     def _get_image_version(self):
         image_version = 'latest'
 
-        if self.get_config_value('image-version'):
-            image_version = self.get_config_value('image-version')
+        if self.get_config_value('container-image-version'):
+            image_version = self.get_config_value('container-image-version')
         else:
-            if(self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE) \
-            and self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE).get('image-version')):
-                image_version = self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE).\
-                                get('image-version')
+            push_container_image_results = self.get_step_results(DefaultSteps.PUSH_CONTAINER_IMAGE)
+            if(push_container_image_results and \
+                push_container_image_results.get('container-image-version')
+            ):
+                image_version = push_container_image_results.get('container-image-version')
             else:
                 print('No image version found in metadata, using \"latest\"')
         return image_version
@@ -468,11 +476,11 @@ users:
 
         argocd_app_name = self._get_app_name()
         version = self._get_image_version()
-        url = self._get_image_url()
+        container_image_repo_uri = self.__get_container_image_repository_uri()
         timestamp = str(datetime.now())
         repo_branch = self._get_repo_branch()
         endpoint_url = self._get_endpoint_url()
-        jinja_runtime_step_config = {'image_url' : url,
+        jinja_runtime_step_config = {'container_image_repo_uri' : container_image_repo_uri,
                                      'image_version' : version,
                                      'timestamp' : timestamp,
                                      'repo_branch' : repo_branch,
@@ -499,7 +507,8 @@ users:
                 values_file=values_file_name, all=error)) from error
 
     def _get_tag(self, repo_directory):
-
+        """TODO: doc me
+        """
         tag = 'latest'
         if(self.get_step_results(DefaultSteps.TAG_SOURCE) \
           and self.get_step_results(DefaultSteps.TAG_SOURCE).get('tag')):

--- a/tssc/step_implementers/generate_metadata/__init__.py
+++ b/tssc/step_implementers/generate_metadata/__init__.py
@@ -17,7 +17,7 @@ minimally produce the following step results.
 | Result Key  | Description
 |-------------|------------
 | `version`   | Constructed semantic version (https://semver.org/).
-| `image-tag` | Constructed semantic version (https://semver.org/) modified \
+| `container-image-version` | Constructed semantic version (https://semver.org/) modified \
                 to work as a container image tag.
 """
 

--- a/tssc/step_implementers/generate_metadata/semantic_version.py
+++ b/tssc/step_implementers/generate_metadata/semantic_version.py
@@ -64,7 +64,7 @@ Results output by this step.
 | Result Key  | Description
 |-------------|------------
 | `version`   | Constructed semantic version (https://semver.org/).
-| `image-tag` | Constructed semantic version (https://semver.org/) without build #
+| `container-image-version` | Constructed semantic version (https://semver.org/) without build #
 
 Examples
 --------
@@ -89,7 +89,7 @@ Examples
         'pre-release': 'feature_test0',
         'build': 'abc123',
         'version': '42.1.0-feature_foo+abc123',
-        'image-tag': '42.1.0-feature_foo'
+        'container-image-version': '42.1.0-feature_foo'
       }
     }}
 
@@ -113,7 +113,7 @@ Examples
         'pre-release': 'master',
         'build': 'abc123',
         'version': '42.1.0+abc123',
-        'image-tag': '42.1.0'
+        'container-image-version': '42.1.0'
       }
     }}
 """
@@ -212,7 +212,7 @@ class SemanticVersion(StepImplementer): # pylint: disable=too-few-public-methods
 
         results = {
             'version': version,
-            'image-tag': image_tag
+            'container-image-version': image_tag
         }
 
         return results

--- a/tssc/step_implementers/push_container_image/__init__.py
+++ b/tssc/step_implementers/push_container_image/__init__.py
@@ -18,7 +18,7 @@ minimally produce the following step results.
 
 | Result Key  | Description
 |-------------|------------
-| `image-tag` | Pushed destination image tag
+| `container-image-version` | Pushed destination image tag
 """
 
 from .skopeo import Skopeo


### PR DESCRIPTION
# problem
currently there is term confusion between `image-tag`, `image-url` and `image-version`. Somteims `image-tag` is just the part after `:` sometimes it is being used as the entire URI:TAG.

# solution
Need to standardize:

`container-image-tag = container-image-uri:container-image-version`

swaps:
* `image-url` -> `container-image-uri`
* `image-tag` -> `container-image-tag` or `container-image-version` depending on how it was being used