### PR TITLE
fixes to do with tls-verify flags

### DIFF
--- a/tests/step_implementers/create_container_image/test_buildah.py
+++ b/tests/step_implementers/create_container_image/test_buildah.py
@@ -68,7 +68,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
                     'create-container-image': {
                         'implementer': 'Buildah',
                         'config': {
-                            'tlsverify' : None,
+                            'tls-verify' : None,
                         }
                     }
                 }
@@ -76,7 +76,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseTSSCTestCase):
 
             with self.assertRaisesRegex(
                     AssertionError,
-                    r"The runtime step configuration \(.*\) is missing the required configuration keys \(\['tlsverify'\]\)"):
+                    r"The runtime step configuration \(.*\) is missing the required configuration keys \(\['tls-verify'\]\)"):
                 run_step_test_with_result_validation(temp_dir, 'create-container-image', config, {})
 
     def test_create_container_image_specify_buildah_implementer_no_dockerfile(self):

--- a/tssc/__init__.py
+++ b/tssc/__init__.py
@@ -377,7 +377,7 @@ From least precedence to highest precedence.
           #context: '.'
 
           # Optional.
-          #tlsverify: true
+          #tls-verify: true
 
           # Optional.
           #format: 'oci'
@@ -687,7 +687,7 @@ From least precedence to highest precedence.
           #context: '.'
 
           # Optional.
-          #tlsverify: true
+          #tls-verify: true
 
           # Optional.
           #format: 'oci'

--- a/tssc/step_implementers/create_container_image/__init__.py
+++ b/tssc/step_implementers/create_container_image/__init__.py
@@ -9,7 +9,7 @@ accept minimally the following configuration options.
 |-----------------|------------
 | `imagespecfile` | Image specification file name
 | `context`       | Parent path to the image specification file
-| `tlsverify`     | Verify TLS certs when pulling images?
+| `tls-verify`    | Verify TLS certs when pulling images?
 
 Results
 -------

--- a/tssc/step_implementers/create_container_image/buildah.py
+++ b/tssc/step_implementers/create_container_image/buildah.py
@@ -11,7 +11,7 @@ from runtime configuration.
 |-------------------|-----------|----------------|-----------
 | `imagespecfile`   | True      | `'Dockerfile'` | File defining the container image
 | `context`         | True      | `'.'`          | Context to build the container image in
-| `tlsverify`       | True      | `'true'`       | Whether to verify TLS when pulling parent images
+| `tls-verify`      | True      | `'true'`       | Whether to verify TLS when pulling parent images
 | `format`          | True      | `'oci'`        | format of the built image's manifest and metadata
 | `containers-config-auth-file` | True | `'~/.buildah-auth.json'` | \
     Path to the container registry authentication file \
@@ -67,7 +67,7 @@ DEFAULT_CONFIG = {
     'context': '.',
 
     # Verify TLS Certs?
-    'tlsverify': 'true',
+    'tls-verify': 'true',
 
     # Format of the produced image
     'format': 'oci'
@@ -77,7 +77,7 @@ REQUIRED_CONFIG_KEYS = [
     'containers-config-auth-file',
     'imagespecfile',
     'context',
-    'tlsverify',
+    'tls-verify',
     'format',
     'service-name',
     'application-name'
@@ -182,7 +182,7 @@ class Buildah(StepImplementer):
             sh.buildah.bud(  # pylint: disable=no-member
                 '--storage-driver=vfs',
                 '--format=' + self.get_config_value('format'),
-                '--tls-verify=' + str(self.get_config_value('tlsverify')),
+                '--tls-verify=' + str(self.get_config_value('tls-verify')),
                 '--layers', '-f', image_spec_file,
                 '-t', tag,
                 '--authfile', containers_config_auth_file,

--- a/tssc/step_implementers/sign_container_image/podman_sign.py
+++ b/tssc/step_implementers/sign_container_image/podman_sign.py
@@ -7,11 +7,10 @@ Step configuration expected as input to this step.
 Could come from either configuration file or
 from runtime configuration.
 
-| Configuration Key                        | Required? | Default | Description
-|------------------------------------------|-----------|---------|-------------
-| `container-image-signer-pgp-private-key` | True      |         | PGP Private Key /
-                                                                   used to sign /
-                                                                   the image
+| Configuration Key                        | Required? | Default  | Description
+|------------------------------------------|-----------|----------|-------------
+| `container-image-signer-pgp-private-key` | True      |          | PGP Private Key used to \
+                                                                    sign the image
 
 
 Expected Previous Step Results
@@ -29,19 +28,19 @@ Results output by this step.
 
 | Result Key                                          | Description
 |-----------------------------------------------------|------------
-| `container-image-signature-private-key-fingerprint` | Fingerprint for the private key for /
+| `container-image-signature-private-key-fingerprint` | Fingerprint for the private key for \
                                                         image signing
-| `container-image-signature-file-path`               | File path where signature is located /
-                                                        eg) /tmp/jkeam/hello-node@/
-                                                            sha256=2cbdb73c9177e63/
-                                                            e85d267f738e99e368db3f/
-                                                            806eab4c541f5c6b719e69/
+| `container-image-signature-file-path`               | File path where signature is located \
+                                                        eg) /tmp/jkeam/hello-node@\
+                                                            sha256=2cbdb73c9177e63\
+                                                            e85d267f738e99e368db3f\
+                                                            806eab4c541f5c6b719e69\
                                                             f1a2b/signature-1
-| `container-image-signature-name`                    | Fully qualified name of the name /
-                                                        including organization, repo, and hash /
-                                                        eg) jkeam/hello-node@sha256=/
-                                                            2cbdb73c9177e63e85d267f738e9/
-                                                            9e368db3f806eab4c541f5c6b719/
+| `container-image-signature-name`                    | Fully qualified name of the name \
+                                                        including organization, repo, and hash \
+                                                        eg) jkeam/hello-node@sha256=\
+                                                            2cbdb73c9177e63e85d267f738e9\
+                                                            9e368db3f806eab4c541f5c6b719\
                                                             e69f1a2b/signature-1
 """
 
@@ -206,10 +205,10 @@ class PodmanSign(StepImplementer):
             # NOTE: for some reason the output from podman sign goes to stderr so....
             #       merge the two streams
             sh.podman.image( # pylint: disable=no-member
-                'sign',
-                f'--sign-by={pgp_private_key_fingerprint}',
-                f'--directory={image_signatures_directory}',
-                f'docker://{container_image_tag}',
+                "sign",
+                f"--sign-by={pgp_private_key_fingerprint}",
+                f"--directory={image_signatures_directory}",
+                f"docker://{container_image_tag}",
                 _out=sys.stdout,
                 _err_to_out=True,
                 _tee='out'


### PR DESCRIPTION
# Fixes
* NAPSSPO-1059 - sign-container-image - podman_sign - missing option to pass ssl-verify to podman image sign
* sign-container-image - podman_sign - cleanup
    - origonal purpose was to add otpion to set `--tls-verify` false, but turns out that `podman image sign` doesn't have that option...