### PR TITLE
Use --upload-file instead of --data-binary for curl_push because this…

### DIFF
--- a/tests/step_implementers/sign_container_image/test_curl_push.py
+++ b/tests/step_implementers/sign_container_image/test_curl_push.py
@@ -145,7 +145,7 @@ class TestStepImplementerSignContainerImageCurlPush(BaseStepImplementerTestCase)
                 '--header', StringRegexParam(r'X-Checksum-Sha1:.+'),
                 '--header', StringRegexParam(r'X-Checksum-MD5:.+'),
                 '--user', "admin:adminPassword",
-                '--data-binary', f"@{container_image_signature_file_path}",
+                '--upload-file', container_image_signature_file_path,
                 f"https://sigserver/signatures/{container_image_signature_name}",
                 _out=Any(IOBase),
                 _err_to_out=True,

--- a/tssc/step_implementers/sign_container_image/curl_push.py
+++ b/tssc/step_implementers/sign_container_image/curl_push.py
@@ -195,7 +195,7 @@ class CurlPush(StepImplementer):
                 '--header', f'X-Checksum-Sha1:{signature_file_sha1}',
                 '--header', f'X-Checksum-MD5:{signature_file_md5}',
                 '--user', f"{signature_server_username}:{signature_server_password}",
-                '--data-binary', f"@{container_image_signature_file_path}",
+                '--upload-file', container_image_signature_file_path,
                 container_image_signature_url,
                 _out=stdout_callback,
                 _err_to_out=True,


### PR DESCRIPTION
… fails uploading to nexus.

In the interest of supporting both Artifactory and Nexus for the image signature server, we should use `--upload-file` since it's accepted by both implementations.